### PR TITLE
feat: Define an additional key for switching dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 - Optimized searching for variants of 長音 (ー) and 旧字体 to perform fewer
   lookups while considering all 長音 variations for name entries.
 
+- Defined an additional key that can be configured to switch dictionaries,
+  <kbd>n</kbd>, since <kbd>Shift</kbd> can be unavailable when Firefox's
+  resist fingerprinting mode is enabled.
+
 ## 1.0.0 (2021-06-15) (Safari only)
 
 - Added new default (gray) theme.

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,7 +89,7 @@ interface KeySetting {
 export const DEFAULT_KEY_SETTINGS: KeySetting[] = [
   {
     name: 'nextDictionary',
-    keys: ['Shift', 'Enter'],
+    keys: ['Shift', 'Enter', 'n'],
     enabledKeys: ['Shift', 'Enter'],
     l10nKey: 'options_popup_switch_dictionaries',
   },


### PR DESCRIPTION
Shift is not available when resist fingerprinting is enabled and Enter can be inconvenient.

Fixes #659.