### PR TITLE
feat: flip moon orientation upon double-tap

### DIFF
--- a/src/puck.ts
+++ b/src/puck.ts
@@ -83,7 +83,6 @@ export class LookupPuck {
   private targetOffset: { x: number; y: number } = { x: 0, y: 0 };
   private targetOrientation: 'above' | 'below' = 'above';
   private cachedViewportDimensions: ViewportDimensions | null = null;
-  private isBeingPressedOrDragged: boolean = false;
 
   constructor(private safeAreaProvider: SafeAreaProvider) {}
 
@@ -283,7 +282,12 @@ export class LookupPuck {
       !this.earthWidth ||
       !this.earthHeight ||
       !this.enabled ||
-      !this.isBeingPressedOrDragged
+      // i.e. if it's neither being pressed nor dragged
+      !(
+        this.clickState.kind === 'dragging' ||
+        this.clickState.kind === 'firstpointerdown' ||
+        this.clickState.kind === 'secondpointerdown'
+      )
     ) {
       return;
     }
@@ -398,7 +402,6 @@ export class LookupPuck {
     event.preventDefault();
     event.stopPropagation();
 
-    this.isBeingPressedOrDragged = true;
     this.puck.style.pointerEvents = 'none';
     this.puck.classList.add('dragging');
     this.puck.setPointerCapture(event.pointerId);
@@ -420,7 +423,6 @@ export class LookupPuck {
 
   // May be called manually (without an event), or upon 'pointerup' or 'pointercancel'.
   private readonly stopDraggingPuck = (event?: PointerEvent) => {
-    this.isBeingPressedOrDragged = false;
     if (this.puck) {
       this.puck.style.pointerEvents = 'revert';
       this.puck.classList.remove('dragging');

--- a/src/puck.ts
+++ b/src/puck.ts
@@ -330,10 +330,16 @@ export class LookupPuck {
     target.dispatchEvent(mouseEvent);
   };
 
+  private gotPuckPointerDown: boolean = false;
+  private doubleClickStart: number | null = null;
+  private static readonly doubleClickHysteresis = 300;
+
   private readonly onPuckPointerDown = (event: PointerEvent) => {
     if (!this.enabled || !this.puck) {
       return;
     }
+
+    this.gotPuckPointerDown = true;
 
     event.preventDefault();
     event.stopPropagation();
@@ -348,51 +354,69 @@ export class LookupPuck {
     window.addEventListener('pointercancel', this.stopDraggingPuck);
   };
 
-  private readonly stopDraggingPuck = () => {
+  private readonly onPuckClick = () => {
+    const dateNow = Date.now();
+
+    // If a click has preceded this, determine whether this is a double-click or a single-click.
+    if (this.doubleClickStart) {
+      if (dateNow - this.doubleClickStart < LookupPuck.doubleClickHysteresis) {
+        this.onPuckDoubleClick();
+
+        // Let's handle double-clicks exclusively from single-clicks (and so bail out here).
+        return;
+      }
+    }
+
+    this.doubleClickStart = dateNow;
+
+    // TODO: toggle whether the puck is enabled or disabled.
+  };
+
+  private readonly onPuckDoubleClick = () => {
+    this.targetOrientation =
+      this.targetOrientation === 'above' ? 'below' : 'above';
+    this.setPositionWithinSafeArea(this.puckX, this.puckY);
+
+    this.doubleClickStart = null;
+  };
+
+  // May be called manually (without an event), or upon 'pointerup' or 'pointercancel'.
+  private readonly stopDraggingPuck = (event?: PointerEvent) => {
     this.isBeingDragged = false;
     if (this.puck) {
       this.puck.style.pointerEvents = 'revert';
       this.puck.classList.remove('dragging');
-
-      // Update the target orientation if the puck was parked low down on the
-      // screen.
-      const { viewportHeight } = this.getViewportDimensions(
-        this.puck?.ownerDocument || document
-      );
-
-      const { bottom: safeAreaBottom } =
-        this.safeAreaProvider.getSafeArea() || {
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-        };
-
-      // The distance from the bottom of the earth (which can only travel within
-      // the safe area) to the centre of the moon (which is the point from which
-      // the mouse events are fired). This is effectively the height of the
-      // "blind spot" that a puck supporting only the "above" orientation would
-      // have.
-      const activePuckVerticalExtent =
-        this.earthHeight +
-        (this.targetAbsoluteOffsetYAbove - this.earthHeight / 2);
-      this.targetOrientation =
-        this.puckY >= viewportHeight - safeAreaBottom - activePuckVerticalExtent
-          ? 'below'
-          : 'above';
       this.setPositionWithinSafeArea(this.puckX, this.puckY);
     }
 
     window.removeEventListener('pointermove', this.onWindowPointerMove);
     window.removeEventListener('pointerup', this.stopDraggingPuck);
     window.removeEventListener('pointercancel', this.stopDraggingPuck);
+
+    if (event) {
+      const targetIsPuckOrRoot =
+        event.target === this.puck || event.target === this.container;
+      if (event.type === 'pointercancel' || !targetIsPuckOrRoot) {
+        // Stop tracking this click and wait for the next 'pointerdown' to come along instead.
+        this.gotPuckPointerDown = false;
+      } else if (
+        event.type === 'pointerup' &&
+        targetIsPuckOrRoot &&
+        this.gotPuckPointerDown
+      ) {
+        // Prevent any double-taps turning into a zoom
+        event.preventDefault();
+        this.onPuckClick();
+      }
+    }
   };
 
   private readonly noOpPointerUpHandler = () => {};
+  private container: HTMLElement | null = null;
 
   render({ doc, theme }: PuckRenderOptions): void {
     // Set up shadow tree
-    const container = getOrCreateEmptyContainer({
+    this.container = getOrCreateEmptyContainer({
       doc,
       id: LookupPuck.id,
       styles: puckStyles.toString(),
@@ -410,7 +434,7 @@ export class LookupPuck {
     moon.classList.add('moon');
     this.puck.append(moon);
 
-    container.shadowRoot!.append(this.puck);
+    this.container.shadowRoot!.append(this.puck);
 
     // Set theme styles
     this.puck.classList.add(getThemeClass(theme));
@@ -510,6 +534,7 @@ export class LookupPuck {
 
   unmount(): void {
     removePuck();
+    this.container = null;
     this.disable();
     this.puck = undefined;
   }

--- a/src/puck.ts
+++ b/src/puck.ts
@@ -30,6 +30,22 @@ export interface PuckMouseEvent extends MouseEvent {
   fromPuck: true;
 }
 
+type ClickState =
+  | {
+      kind: 'idle';
+    }
+  | {
+      kind: 'gotpointerdown';
+    }
+  | {
+      kind: 'firstclick';
+      timeout: number;
+    }
+  | {
+      kind: 'firstclickwithpointerdown';
+      timeout: number;
+    };
+
 export class LookupPuck {
   public static id: string = 'tenten-ja-puck';
   private puck: HTMLDivElement | undefined;
@@ -330,8 +346,7 @@ export class LookupPuck {
     target.dispatchEvent(mouseEvent);
   };
 
-  private gotPuckPointerDown: boolean = false;
-  private doubleClickStart: number | null = null;
+  private clickState: ClickState = { kind: 'idle' };
   private static readonly doubleClickHysteresis = 300;
 
   private readonly onPuckPointerDown = (event: PointerEvent) => {
@@ -339,7 +354,14 @@ export class LookupPuck {
       return;
     }
 
-    this.gotPuckPointerDown = true;
+    if (this.clickState.kind === 'idle') {
+      this.clickState = { kind: 'gotpointerdown' };
+    } else if (this.clickState.kind === 'firstclick') {
+      this.clickState = {
+        ...this.clickState,
+        kind: 'firstclickwithpointerdown',
+      };
+    }
 
     event.preventDefault();
     event.stopPropagation();
@@ -355,20 +377,6 @@ export class LookupPuck {
   };
 
   private readonly onPuckClick = () => {
-    const dateNow = Date.now();
-
-    // If a click has preceded this, determine whether this is a double-click or a single-click.
-    if (this.doubleClickStart) {
-      if (dateNow - this.doubleClickStart < LookupPuck.doubleClickHysteresis) {
-        this.onPuckDoubleClick();
-
-        // Let's handle double-clicks exclusively from single-clicks (and so bail out here).
-        return;
-      }
-    }
-
-    this.doubleClickStart = dateNow;
-
     // TODO: toggle whether the puck is enabled or disabled.
   };
 
@@ -376,8 +384,6 @@ export class LookupPuck {
     this.targetOrientation =
       this.targetOrientation === 'above' ? 'below' : 'above';
     this.setPositionWithinSafeArea(this.puckX, this.puckY);
-
-    this.doubleClickStart = null;
   };
 
   // May be called manually (without an event), or upon 'pointerup' or 'pointercancel'.
@@ -398,15 +404,30 @@ export class LookupPuck {
         event.target === this.puck || event.target === this.container;
       if (event.type === 'pointercancel' || !targetIsPuckOrRoot) {
         // Stop tracking this click and wait for the next 'pointerdown' to come along instead.
-        this.gotPuckPointerDown = false;
-      } else if (
-        event.type === 'pointerup' &&
-        targetIsPuckOrRoot &&
-        this.gotPuckPointerDown
-      ) {
+        if (
+          this.clickState.kind === 'firstclick' ||
+          this.clickState.kind === 'firstclickwithpointerdown'
+        ) {
+          window.clearTimeout(this.clickState.timeout);
+        }
+        this.clickState = { kind: 'idle' };
+      } else if (event.type === 'pointerup' && targetIsPuckOrRoot) {
         // Prevent any double-taps turning into a zoom
         event.preventDefault();
-        this.onPuckClick();
+
+        if (this.clickState.kind === 'gotpointerdown') {
+          this.clickState = {
+            kind: 'firstclick',
+            timeout: window.setTimeout(() => {
+              this.clickState = { kind: 'idle' };
+            }, LookupPuck.doubleClickHysteresis),
+          };
+          this.onPuckClick();
+        } else if (this.clickState.kind === 'firstclickwithpointerdown') {
+          window.clearTimeout(this.clickState.timeout);
+          this.clickState = { kind: 'idle' };
+          this.onPuckDoubleClick();
+        }
       }
     }
   };
@@ -558,6 +579,13 @@ export class LookupPuck {
       this.puck.removeEventListener('pointerdown', this.onPuckPointerDown);
     }
     window.removeEventListener('pointerup', this.noOpPointerUpHandler);
+    if (
+      this.clickState.kind === 'firstclick' ||
+      this.clickState.kind === 'firstclickwithpointerdown'
+    ) {
+      window.clearTimeout(this.clickState.timeout);
+    }
+    this.clickState = { kind: 'idle' };
   }
 }
 


### PR DESCRIPTION
Continuing from https://github.com/shirakaba/10ten-ja-reader/pull/16 (closed due to force-push).

I've refactored it into a state machine, though not completely sure I've followed your state flow. I ended up introducing intermediate states indicating whether a `pointerdown` event had been received on the puck (rather than some other element) prior to the `pointerup` (may be overcautious).

For discussion: do we prefer:

```ts
type ClickState =
  | {
      kind: 'idle';
    }
  | {
      kind: 'gotpointerdown';
    }
  | {
      kind: 'firstclick';
      timeout: number;
    }
  | {
      kind: 'firstclickwithpointerdown';
      timeout: number;
    };
```

... or:

```ts
type ClickState =
  | {
      kind: 'idle';
      gotPointerDown: boolean;
    }
  | {
      kind: 'firstclick';
      gotPointerDown: boolean;
      timeout: number;
    };
```

I'm not too practised at modelling state machines, but suspect that being able to switch on `kind` alone is more convenient than storing extra state fields within each kind of state.

> Do we also need to check that when we get a 'pointerup' that that it's not the end of dragging the puck? Or perhaps we already do that?

Not quite following. Even before this PR, we've been calling `stopDraggingPuck()` on any `pointerup` event fired on the window, so we've always treated this as the end of dragging the puck.

> In any case, maybe it's better to handle this after we fix the issue with pointerup on iframes? #14 (comment)

I've decided to tackle this refactor while the logic was fresh in my mind. I think it does make sense to address that issue first, though hopefully it's not a significant refactor even if this PR does overtake the PR for that issue.

> Perhaps it might even be better to roll the isBeingDragged member into the same state machine?

Good point. I wonder if `isBeingDragged` is simply equivalent to all cases of `this.clickState.kind !== 'idle'` at this point.

> I think we probably don't want to enable/disable the puck until the 300ms has elapsed?

Not sure whether it's doing this or not at this point (think I need some coffee). Will come back and reassess this later.

> Bear in mind that Jake Archibald has recently been struggling with pointer events in Safari it seems so if we come across odd behaviour it might be worth checking if anything of the following discussions overlap with what we're doing

Hmm. I need to try out my puck iframes support patch on Safari to get a better picture of what's going on. I did only test it on Firefox in the end, unfortunately.