### PR TITLE
feat: toggle puck lookups upon single-tap

### DIFF
--- a/css/puck.css
+++ b/css/puck.css
@@ -24,6 +24,9 @@
   --rest-x-offset: -20px;
   --rest-y-offset: -20px;
 }
+.puck.lookup-disabled {
+  opacity: 0.5;
+}
 
 .earth,
 .moon {

--- a/css/puck.css
+++ b/css/puck.css
@@ -24,7 +24,7 @@
   --rest-x-offset: -20px;
   --rest-y-offset: -20px;
 }
-.puck.lookup-disabled {
+.puck.lookup-inactive {
   opacity: 0.5;
 }
 

--- a/css/puck.css
+++ b/css/puck.css
@@ -17,6 +17,7 @@
   z-index: 1000002;
   /* Stops the screen scrolling on touch devices while dragging the puck around. */
   touch-action: none;
+  transition: opacity 0.1s ease-in-out;
 
   --target-x-offset: 0px;
   --target-y-offset: 0px;
@@ -116,7 +117,7 @@
   transition: transform 0.1s, opacity 0.3s;
 }
 
-.puck.dragging .moon,
+.puck.dragging:not(.lookup-inactive) .moon,
 .puck.hold-position .moon {
   transform: translate(var(--target-x-offset), var(--target-y-offset));
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -91,6 +91,7 @@ import {
   removePuck,
   LookupPuck,
   PuckMouseEvent,
+  LookupPuckEnabledState,
 } from './puck';
 import { query, QueryResult } from './query';
 import {
@@ -292,7 +293,9 @@ export class ContentHandler {
 
   setUpPuck() {
     if (!this.puck) {
-      this.puck = new LookupPuck(this.safeAreaProvider);
+      this.puck = new LookupPuck(this.safeAreaProvider, () => {
+        this.clearResult();
+      });
     }
 
     this.puck.render({
@@ -300,7 +303,7 @@ export class ContentHandler {
       icon: this.config.toolbarIcon,
       theme: this.config.popupStyle,
     });
-    this.puck.enable();
+    this.puck.setEnabledState(LookupPuckEnabledState.enableGesturesAndLookup);
   }
 
   tearDownPuck() {

--- a/src/content.ts
+++ b/src/content.ts
@@ -91,7 +91,6 @@ import {
   removePuck,
   LookupPuck,
   PuckMouseEvent,
-  LookupPuckEnabledState,
 } from './puck';
 import { query, QueryResult } from './query';
 import {
@@ -303,7 +302,7 @@ export class ContentHandler {
       icon: this.config.toolbarIcon,
       theme: this.config.popupStyle,
     });
-    this.puck.setEnabledState(LookupPuckEnabledState.enableGesturesAndLookup);
+    this.puck.setEnabledState('active');
   }
 
   tearDownPuck() {


### PR DESCRIPTION
Upon a single-tap, the puck will remain draggable and responsive to single taps (and double taps, now that I think about it – I'm not too bothered about it either way) but importantly will stop looking up words.

https://user-images.githubusercontent.com/14055146/132957526-29ab97a7-6bc9-4aff-a540-d95808182e79.mp4

This allows you to dismiss the puck for a bit whilst trying to focus on the overall sentence, instead of having to find an adequate bit of whitespace to park it in.