### PR TITLE
fix: drop bogus { type: 'module' } from Worker instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ app.
 - (Chrome, Edge) Migrated to Manifest version 3.
 - (Safari) Fixed a bug where the toolbar icon would get stuck not updating.
 
+## [1.13.6] - TBD (Firefox, Thunderbird only)
+
+- Fixed breakage on Firefox beta
+  ([#1080](https://github.com/birchill/10ten-ja-reader/issues/1080)).
+
 ## [1.13.5] - 2022-12-02
 
 - Added support for parsing ざるを得ない endings, e.g. 闘わざるをえなかった.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <div align="center">
   <img src="images/10ten-ja-reader.svg" alt="10ten Japanese Reader" width="200" height="200" />
   <h1>10ten Japanese Reader</h1>
-  
+
   <p>
     Hi fellow Japanese reader! Formerly known as Rikaichamp, this browser extension lets you look up Japanese words with the hover of a mouse or tap of a screen. 
   </p>
-  
+
   <p>
     <a href="https://twitter.com/10tenstudy"><img src="https://img.shields.io/twitter/follow/10tenstudy" alt="Follow @10tenstudy"></a>
     <a href=""><img src="https://github.com/birchill/10ten-ja-reader/workflows/Automated%20tests/badge.svg" alt="automated test status" /></a>

--- a/src/worker/jpdict-worker-backend.ts
+++ b/src/worker/jpdict-worker-backend.ts
@@ -9,7 +9,7 @@ export class JpdictWorkerBackend implements JpdictBackend {
   private listeners: Array<JpdictListener> = [];
 
   constructor() {
-    this.worker = new Worker('./10ten-ja-jpdict.js', { type: 'module' });
+    this.worker = new Worker('./10ten-ja-jpdict.js');
     this.worker.onmessageerror = (event: MessageEvent) => {
       console.error(`Worker error: ${JSON.stringify(event)}`);
       void Bugsnag.notify(`Worker error: ${JSON.stringify(event)}`);


### PR DESCRIPTION
This was causing Firefox beta 111 to break since it starts parsing this
annotation and then failing when it is set.

Fixes #1080.
