### PR TITLE
Add a setting to disable "tap to lookup"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ app.
 
 - Added a setting for changing the font size of the popup.
 - Made options page support dark mode.
+- Added an option to disable looking up by tapping on them on touchscreen devices
+  ([#1005](https://github.com/birchill/10ten-ja-reader/issues/1005)).
 
 ## [1.14.3] - 2023-06-05 (Chrome, Edge only)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,18 @@ Other options include:
 
 (I believe the latter two options only apply to Firefox.)
 
+### Firefox for Android
+
+Instructions are [here](https://extensionworkshop.com/documentation/develop/developing-extensions-for-firefox-for-android/).
+
+Once you've set up `adb` correctly and got the device ID, you should be able to run:
+
+```
+yarn web-ext run -t firefox-android --adb-device <device ID> --firefox-apk org.mozilla.fenix
+```
+
+That will use the version of `web-ext` installed by this project.
+
 ## Testing
 
 ```

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1914,6 +1914,10 @@
     "message": "天 (Heaven)",
     "description": "Alt text for the 天 toolbar icon"
   },
+  "options_touch_enable_tap_lookup": {
+    "message": "Look up text by tapping",
+    "description": "Checkbox label for setting to enable looking up by tapping a word"
+  },
   "options_update_check_button_label": {
     "message": "Check for updates",
     "description": "Label for the button to check for database updates"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1914,6 +1914,10 @@
     "message": "天",
     "description": "Alt text for the 天 toolbar icon"
   },
+  "options_touch_enable_tap_lookup": {
+    "message": "タップでテキストを調べる",
+    "description": "Checkbox label for setting to enable looking up by tapping a word"
+  },
   "options_update_check_button_label": {
     "message": "更新を確認",
     "description": "Label for the button to check for database updates"

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -1914,6 +1914,10 @@
     "message": "天",
     "description": "Alt text for the 天 toolbar icon"
   },
+  "options_touch_enable_tap_lookup": {
+    "message": "点击查询文本",
+    "description": "Checkbox label for setting to enable looking up by tapping a word"
+  },
   "options_update_check_button_label": {
     "message": "检查更新",
     "description": "Label for the button to check for database updates"

--- a/css/options.css
+++ b/css/options.css
@@ -73,6 +73,14 @@
   }
 }
 
+.needs-touch {
+  display: none;
+}
+
+.has-touch .needs-touch {
+  display: block;
+}
+
 /*
  * Container style
  */

--- a/html/options.html
+++ b/html/options.html
@@ -219,6 +219,16 @@
             </a>
           </div>
         </div>
+        <div id="touch-interactivity-section" class="needs-touch">
+          <div class="checkbox-row">
+            <input
+              type="checkbox"
+              id="enableTapLookup"
+              name="enableTapLookup"
+            />
+            <label for="enableTapLookup">Look up text by tapping<span class="new-badge">New!</span></label>
+          </div>
+        </div>
         <p>Tab position</p>
         <fieldset>
           <div class="tabdisplay-select icon-radio -with-labels -bw-inactive"

--- a/html/options.html.src
+++ b/html/options.html.src
@@ -218,6 +218,17 @@
             </a>
           </div>
         </div>
+        <div id=touch-interactivity-section class=needs-touch>
+          <div class="checkbox-row">
+            <input
+              type="checkbox"
+              id="enableTapLookup"
+              name="enableTapLookup"
+            />
+            <label for="enableTapLookup">__MSG_options_touch_enable_tap_lookup__<span
+              class=new-badge>__MSG_options_new_badge_text__</span></label>
+          </div>
+        </div>
         <p>__MSG_options_tab_position_label__</p>
         <fieldset>
           <div

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -63,6 +63,7 @@ interface Settings {
   accentDisplay?: AccentDisplay;
   contextMenuEnable?: boolean;
   dictLang?: DbLanguageId;
+  enableTapLookup?: boolean;
   fontSize?: FontSize;
   fxCurrency?: string;
   hasDismissedMouseOnboarding?: boolean;
@@ -484,6 +485,27 @@ export class Config {
       for (const listener of this.changeListeners) {
         listener(changes);
       }
+    }
+  }
+
+  // enableTapLookup: Defaults to true
+
+  get enableTapLookup(): boolean {
+    return this.settings.enableTapLookup ?? true;
+  }
+
+  set enableTapLookup(value: boolean) {
+    const storedSetting = this.settings.enableTapLookup;
+    if (storedSetting === value) {
+      return;
+    }
+
+    if (value) {
+      void browser.storage.sync.remove('enableTapLookup');
+      delete this.settings.enableTapLookup;
+    } else {
+      void browser.storage.sync.set({ enableTapLookup: value });
+      this.settings.enableTapLookup = value;
     }
   }
 
@@ -1048,6 +1070,7 @@ export class Config {
     return {
       accentDisplay: this.accentDisplay,
       dictLang: this.dictLang,
+      enableTapLookup: this.enableTapLookup,
       fx:
         this.fxData && this.fxCurrency in this.fxData.rates
           ? {

--- a/src/common/content-config-params.ts
+++ b/src/common/content-config-params.ts
@@ -48,6 +48,10 @@ export interface ContentConfigParams {
   // The preferred language for dictionary content.
   dictLang: string;
 
+  // Whether or not tapping text should trigger a look up on touchscreen
+  // devices.
+  enableTapLookup: boolean;
+
   // The preferred currency to convert to, along with its rate and the timestamp
   // for the rate.
   fx: { currency: string; rate: number; timestamp: number } | undefined;

--- a/src/content/content-config.ts
+++ b/src/content/content-config.ts
@@ -114,6 +114,9 @@ export class ContentConfig implements ContentConfigParams {
   get dictLang() {
     return this.params.dictLang;
   }
+  get enableTapLookup() {
+    return this.params.enableTapLookup;
+  }
   get fx() {
     return this.params.fx;
   }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -340,6 +340,10 @@ export class ContentHandler {
       (event.target || document.body).dispatchEvent(mouseMoveEvent);
     };
 
+    if (!this.config.enableTapLookup) {
+      this.touchClickTracker.disable();
+    }
+
     void hasReasonableTimerResolution().then((isReasonable) => {
       if (isReasonable) {
         this.hidePopupWhenMovingAtSpeed = true;
@@ -411,6 +415,12 @@ export class ContentHandler {
           if (this.isTopMostWindow()) {
             this.updatePopup({ fixPosition: true });
           }
+          break;
+
+        case 'enableTapLookup':
+          value
+            ? this.touchClickTracker.enable()
+            : this.touchClickTracker.disable();
           break;
 
         case 'fontSize':

--- a/src/content/puck.ts
+++ b/src/content/puck.ts
@@ -22,13 +22,13 @@ export interface PuckRenderOptions {
   theme: string;
 }
 
-export function isPuckMouseEvent(
-  mouseEvent: MouseEvent
-): mouseEvent is PuckMouseEvent {
-  return !!(mouseEvent as PuckMouseEvent).fromPuck;
+export function isPuckPointerEvent(
+  pointerEvent: PointerEvent
+): pointerEvent is PuckPointerEvent {
+  return !!(pointerEvent as PuckPointerEvent).fromPuck;
 }
 
-export interface PuckMouseEvent extends MouseEvent {
+export interface PuckPointerEvent extends PointerEvent {
   fromPuck: true;
 }
 
@@ -343,6 +343,10 @@ export class LookupPuck {
   }
 
   readonly onWindowPointerMove = (event: PointerEvent) => {
+    if (isPuckPointerEvent(event)) {
+      return;
+    }
+
     if (
       !this.puck ||
       !this.earthWidth ||
@@ -475,15 +479,16 @@ export class LookupPuck {
       return;
     }
 
-    const mouseEvent = new MouseEvent('mousemove', {
+    const pointerEvent = new PointerEvent('pointermove', {
       // Make sure the event bubbles up to the listener on the window
       bubbles: true,
       clientX: targetX,
       clientY: targetY,
+      pointerType: 'mouse',
     });
-    (mouseEvent as PuckMouseEvent).fromPuck = true;
+    (pointerEvent as PuckPointerEvent).fromPuck = true;
 
-    target.dispatchEvent(mouseEvent);
+    target.dispatchEvent(pointerEvent);
   };
 
   private restoreContent() {

--- a/src/content/touch-click-tracker.ts
+++ b/src/content/touch-click-tracker.ts
@@ -1,6 +1,7 @@
 export class TouchClickTracker {
   private wasTouch = false;
   private ignoring = false;
+  private disabled = false;
   onTouchClick?: (event: MouseEvent) => void;
 
   constructor() {
@@ -8,18 +9,29 @@ export class TouchClickTracker {
     this.onTouchEnd = this.onTouchEnd.bind(this);
     this.onClick = this.onClick.bind(this);
 
-    window.addEventListener('touchstart', this.onTouchStart, { passive: true });
-    window.addEventListener('touchend', this.onTouchEnd, { passive: true });
-    // We need to register for clicks on the _body_ because if there is no
-    // click handler on the body element, iOS won't generate click events
-    // from touch taps.
-    document.body?.addEventListener('click', this.onClick);
+    this.addEventListeners();
   }
 
   destroy() {
-    window.removeEventListener('touchstart', this.onTouchStart);
-    window.removeEventListener('touchend', this.onTouchEnd);
-    document.body?.removeEventListener('click', this.onClick);
+    this.removeEventListeners();
+  }
+
+  disable() {
+    if (this.disabled) {
+      return;
+    }
+
+    this.disabled = true;
+    this.removeEventListeners();
+  }
+
+  enable() {
+    if (!this.disabled) {
+      return;
+    }
+
+    this.disabled = false;
+    this.addEventListeners();
   }
 
   startIgnoringClicks() {
@@ -28,6 +40,21 @@ export class TouchClickTracker {
 
   stopIgnoringClicks() {
     this.ignoring = false;
+  }
+
+  private addEventListeners() {
+    window.addEventListener('touchstart', this.onTouchStart, { passive: true });
+    window.addEventListener('touchend', this.onTouchEnd, { passive: true });
+    // We need to register for clicks on the _body_ because if there is no
+    // click handler on the body element, iOS won't generate click events
+    // from touch taps.
+    document.body?.addEventListener('click', this.onClick);
+  }
+
+  private removeEventListeners() {
+    window.removeEventListener('touchstart', this.onTouchStart);
+    window.removeEventListener('touchend', this.onTouchEnd);
+    document.body?.removeEventListener('click', this.onClick);
   }
 
   private onTouchStart() {

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -47,7 +47,7 @@ import { getThemeClass } from '../utils/themes';
 
 import { Command, CommandParams, isValidKey } from './commands';
 import { translateDoc } from './l10n';
-import { possiblyHasPhysicalKeyboard } from '../utils/device';
+import { isTouchDevice, possiblyHasPhysicalKeyboard } from '../utils/device';
 
 startBugsnag();
 
@@ -72,6 +72,9 @@ function completeForm() {
   }
   if (possiblyHasPhysicalKeyboard()) {
     document.documentElement.classList.add('has-keyboard');
+  }
+  if (isTouchDevice()) {
+    document.documentElement.classList.add('has-touch');
   }
 
   // Pop-up
@@ -219,6 +222,12 @@ function completeForm() {
       config.popupInteractive = popupInteractive === 'enable';
     });
   }
+
+  document
+    .getElementById('enableTapLookup')!
+    .addEventListener('click', (event) => {
+      config.enableTapLookup = (event.target as HTMLInputElement).checked;
+    });
 
   const tabDisplayOptions = Array.from(
     document.querySelectorAll('input[type=radio][name=tabDisplay]')
@@ -897,6 +906,7 @@ function fillVals() {
     ? 'enable'
     : 'disable';
   optform.popupStyle.value = config.popupStyle;
+  optform.enableTapLookup.checked = config.enableTapLookup;
   optform.tabDisplay.value = config.tabDisplay;
   optform.toolbarIcon.value = config.toolbarIcon;
   optform.showPuck.value = config.showPuck;


### PR DESCRIPTION
- feat: add a setting to disable looking up words by tapping them
- fix: listen to pointermove events so we can ignore non-mouse events
- chore: add note about debugging on Fenix
