### PR TITLE
Convert kanji reference settings to Preact/Tailwind

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -305,6 +305,13 @@ export class Config {
             updatedChanges[key].newValue = this[key];
           }
           break;
+
+        // Rename the kanji reference key since the name we use to store it
+        // differs from the name we expose via our API.
+        case 'kanjiReferencesV2':
+          updatedChanges.kanjiReferences = changes.kanjiReferencesV2;
+          delete updatedChanges.kanjiReferencesV2;
+          break;
       }
     }
 

--- a/src/common/refs.ts
+++ b/src/common/refs.ts
@@ -1,4 +1,3 @@
-import { KanjiResult } from '@birchill/jpdict-idb';
 import browser from 'webextension-polyfill';
 
 import { DbLanguageId } from './db-languages';
@@ -225,59 +224,4 @@ function getLabelForReference(ref: ReferenceAbbreviation): ReferenceLabel {
     default:
       return REFERENCE_LABELS[ref];
   }
-}
-
-export function getReferenceValue(
-  entry: KanjiResult,
-  ref: ReferenceAbbreviation
-): string {
-  switch (ref) {
-    case 'nelson_r': {
-      // If the Nelson radical is empty, it means it's the same as the regular
-      // radical so we should fall through to that branch.
-      if (entry.rad.nelson) {
-        return `${entry.rad.nelson} ${String.fromCodePoint(
-          entry.rad.nelson + 0x2eff
-        )}`;
-      }
-      // Fall through
-    }
-
-    case 'radical': {
-      const { rad } = entry;
-      const radChar = rad.base ? rad.base.b || rad.base.k : rad.b || rad.k;
-      return `${rad.x} ${radChar}`;
-    }
-
-    case 'kk':
-      return renderKanKen(entry.misc.kk);
-
-    case 'jlpt':
-      return entry.misc.jlpt ? String(entry.misc.jlpt) : '';
-
-    case 'py':
-      return entry.r.py ? entry.r.py.join(', ') : '';
-
-    case 'unicode':
-      return `U+${entry.c.codePointAt(0)!.toString(16).toUpperCase()}`;
-
-    case 'wk':
-      return entry.misc.wk ? String(entry.misc.wk) : '';
-
-    default:
-      return entry.refs[ref] ? String(entry.refs[ref]) : '';
-  }
-}
-
-function renderKanKen(level: number | undefined): string {
-  if (!level) {
-    return '—';
-  }
-  if (level === 15) {
-    return browser.i18n.getMessage('content_kanji_kentei_level_pre', ['1']);
-  }
-  if (level === 25) {
-    return browser.i18n.getMessage('content_kanji_kentei_level_pre', ['2']);
-  }
-  return browser.i18n.getMessage('content_kanji_kentei_level', [String(level)]);
 }

--- a/src/common/refs.ts
+++ b/src/common/refs.ts
@@ -1,6 +1,5 @@
-import browser from 'webextension-polyfill';
-
 import { DbLanguageId } from './db-languages';
+import { TranslateFunctionType } from './i18n';
 
 const SUPPORTED_REFERENCES = [
   // The radical for the kanji (number and character, from rad field)
@@ -165,7 +164,8 @@ const REFERENCE_LABELS: {
 type ReferenceAndLabel = { ref: ReferenceAbbreviation } & ReferenceLabel;
 
 export function getReferenceLabelsForLang(
-  lang: string
+  lang: string,
+  t: TranslateFunctionType
 ): Array<ReferenceAndLabel> {
   const result: Array<ReferenceAndLabel> = [];
 
@@ -173,7 +173,7 @@ export function getReferenceLabelsForLang(
     if (lang !== 'fr' && ref === 'maniette') {
       continue;
     }
-    result.push({ ref, ...getLabelForReference(ref) });
+    result.push({ ref, ...getLabelForReference(ref, t) });
   }
 
   // Sort by short version first since this is what will be shown in the pop-up.
@@ -183,7 +183,8 @@ export function getReferenceLabelsForLang(
 }
 
 export function getSelectedReferenceLabels(
-  selectedRefs: ReadonlyArray<ReferenceAbbreviation>
+  selectedRefs: ReadonlyArray<ReferenceAbbreviation>,
+  t: TranslateFunctionType
 ): Array<ReferenceAndLabel> {
   const result: Array<ReferenceAndLabel> = [];
   const selectedRefsSet = new Set<ReferenceAbbreviation>(selectedRefs);
@@ -192,7 +193,7 @@ export function getSelectedReferenceLabels(
     if (!selectedRefsSet.has(ref)) {
       continue;
     }
-    result.push({ ref, ...getLabelForReference(ref) });
+    result.push({ ref, ...getLabelForReference(ref, t) });
   }
 
   // Sort by short version first since this is what will be shown in the pop-up.
@@ -201,25 +202,28 @@ export function getSelectedReferenceLabels(
   return result;
 }
 
-function getLabelForReference(ref: ReferenceAbbreviation): ReferenceLabel {
+function getLabelForReference(
+  ref: ReferenceAbbreviation,
+  t: TranslateFunctionType
+): ReferenceLabel {
   switch (ref) {
     case 'radical':
-      return { full: browser.i18n.getMessage('ref_label_radical') };
+      return { full: t('ref_label_radical') };
 
     case 'nelson_r':
-      return { full: browser.i18n.getMessage('ref_label_nelson_r') };
+      return { full: t('ref_label_nelson_r') };
 
     case 'kk':
-      return { full: browser.i18n.getMessage('ref_label_kk') };
+      return { full: t('ref_label_kk') };
 
     case 'jlpt':
-      return { full: browser.i18n.getMessage('ref_label_jlpt') };
+      return { full: t('ref_label_jlpt') };
 
     case 'py':
-      return { full: browser.i18n.getMessage('ref_label_py') };
+      return { full: t('ref_label_py') };
 
     case 'unicode':
-      return { full: browser.i18n.getMessage('ref_label_unicode') };
+      return { full: t('ref_label_unicode') };
 
     default:
       return REFERENCE_LABELS[ref];

--- a/src/content/copy-text.ts
+++ b/src/content/copy-text.ts
@@ -4,10 +4,11 @@ import browser from 'webextension-polyfill';
 import { NameResult, Sense, WordResult } from '../background/search-result';
 import { CopyType } from '../common/copy-keys';
 import {
-  getReferenceValue,
   getSelectedReferenceLabels,
   ReferenceAbbreviation,
 } from '../common/refs';
+
+import { getReferenceValue } from './reference-value';
 
 export type CopyEntry =
   | { type: 'word'; data: WordResult }

--- a/src/content/copy-text.ts
+++ b/src/content/copy-text.ts
@@ -173,7 +173,10 @@ export function getEntryToCopy(
         }
 
         if (kanjiReferences.length) {
-          const labels = getSelectedReferenceLabels(kanjiReferences);
+          const labels = getSelectedReferenceLabels(
+            kanjiReferences,
+            browser.i18n.getMessage
+          );
           for (const label of labels) {
             if (
               label.ref === 'nelson_r' &&
@@ -349,7 +352,10 @@ export function getFieldsToCopy(
           result += `\t${components}`;
         }
         if (kanjiReferences.length) {
-          const labels = getSelectedReferenceLabels(kanjiReferences);
+          const labels = getSelectedReferenceLabels(
+            kanjiReferences,
+            browser.i18n.getMessage
+          );
           for (const label of labels) {
             // For some common types we don't produce the label
             switch (label.ref) {

--- a/src/content/popup/kanji.ts
+++ b/src/content/popup/kanji.ts
@@ -1,11 +1,10 @@
 import { KanjiResult } from '@birchill/jpdict-idb';
 import browser from 'webextension-polyfill';
 
-import {
-  getReferenceValue,
-  getSelectedReferenceLabels,
-} from '../../common/refs';
+import { getSelectedReferenceLabels } from '../../common/refs';
 import { html } from '../../utils/builder';
+
+import { getReferenceValue } from '../reference-value';
 
 import { renderFrequency, renderPencil, renderPerson } from './icons';
 import { getLangTag } from './lang-tag';

--- a/src/content/popup/kanji.ts
+++ b/src/content/popup/kanji.ts
@@ -349,7 +349,10 @@ function renderReferences(
     lang: getLangTag(),
   });
 
-  const referenceNames = getSelectedReferenceLabels(options.kanjiReferences);
+  const referenceNames = getSelectedReferenceLabels(
+    options.kanjiReferences,
+    browser.i18n.getMessage
+  );
   let numReferences = 0;
   for (const ref of referenceNames) {
     // Don't show the Nelson radical if it's the same as the regular radical

--- a/src/content/reference-value.ts
+++ b/src/content/reference-value.ts
@@ -1,0 +1,59 @@
+import type { KanjiResult } from '@birchill/jpdict-idb';
+import browser from 'webextension-polyfill';
+
+import type { ReferenceAbbreviation } from '../common/refs';
+
+export function getReferenceValue(
+  entry: KanjiResult,
+  ref: ReferenceAbbreviation
+): string {
+  switch (ref) {
+    case 'nelson_r': {
+      // If the Nelson radical is empty, it means it's the same as the regular
+      // radical so we should fall through to that branch.
+      if (entry.rad.nelson) {
+        return `${entry.rad.nelson} ${String.fromCodePoint(
+          entry.rad.nelson + 0x2eff
+        )}`;
+      }
+      // Fall through
+    }
+
+    case 'radical': {
+      const { rad } = entry;
+      const radChar = rad.base ? rad.base.b || rad.base.k : rad.b || rad.k;
+      return `${rad.x} ${radChar}`;
+    }
+
+    case 'kk':
+      return renderKanKen(entry.misc.kk);
+
+    case 'jlpt':
+      return entry.misc.jlpt ? String(entry.misc.jlpt) : '';
+
+    case 'py':
+      return entry.r.py ? entry.r.py.join(', ') : '';
+
+    case 'unicode':
+      return `U+${entry.c.codePointAt(0)!.toString(16).toUpperCase()}`;
+
+    case 'wk':
+      return entry.misc.wk ? String(entry.misc.wk) : '';
+
+    default:
+      return entry.refs[ref] ? String(entry.refs[ref]) : '';
+  }
+}
+
+function renderKanKen(level: number | undefined): string {
+  if (!level) {
+    return '—';
+  }
+  if (level === 15) {
+    return browser.i18n.getMessage('content_kanji_kentei_level_pre', ['1']);
+  }
+  if (level === 25) {
+    return browser.i18n.getMessage('content_kanji_kentei_level_pre', ['2']);
+  }
+  return browser.i18n.getMessage('content_kanji_kentei_level', [String(level)]);
+}

--- a/src/content/scan-text.ts
+++ b/src/content/scan-text.ts
@@ -99,7 +99,7 @@ export function scanText({
       }
 
       // Check if we should further expand the set of allowed characters in
-      // order to recognize certains types of metadata-type strings (e.g. years
+      // order to recognize certain types of metadata-type strings (e.g. years
       // or floor space measurements).
       ({ textDelimiter, textEnd } = lookForMetadata({
         currentText,

--- a/src/options/CheckboxRow.tsx
+++ b/src/options/CheckboxRow.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'preact';
+
+export function CheckboxRow(
+  props: Omit<ComponentProps<'div'>, 'class' | 'className'>
+) {
+  return (
+    <div
+      {...props}
+      class="my-2 flex items-baseline gap-2 [&>:not(input)]:flex-1 [&>:not(input)]:leading-snug"
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/src/options/KanjiReferenceSetting.fixture.tsx
+++ b/src/options/KanjiReferenceSetting.fixture.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'preact/hooks';
+import { useSelect } from 'react-cosmos/client';
+
+import { DbLanguageId, dbLanguages } from '../common/db-languages';
+import { ReferenceAbbreviation } from '../common/refs';
+import { KanjiReferenceSetting } from './KanjiReferenceSetting';
+
+import './options.css';
+
+export default function () {
+  const [dictLang] = useSelect<DbLanguageId>('dictLang', {
+    // I suspect the React Cosmos typings here are incorrect with regard to
+    // constness.
+    options: dbLanguages as unknown as DbLanguageId[],
+    defaultValue: 'en',
+  });
+
+  const [enabledReferences, setEnabledReferences] = useState<
+    Array<ReferenceAbbreviation>
+  >(['radical', 'nelson_r', 'kk', 'wk', 'py', 'unicode', 'halpern_njecd']);
+  const toggleReference = (ref: ReferenceAbbreviation, value: boolean) => {
+    const referenceSet = new Set(enabledReferences);
+    if (value) {
+      referenceSet.add(ref);
+    } else {
+      referenceSet.delete(ref);
+    }
+    setEnabledReferences([...referenceSet]);
+  };
+
+  const [showKanjiComponents, setShowKanjiComponents] = useState(true);
+
+  return (
+    <KanjiReferenceSetting
+      dictLang={dictLang}
+      enabledReferences={enabledReferences}
+      showKanjiComponents={showKanjiComponents}
+      onToggleReference={toggleReference}
+      onToggleKanjiComponents={setShowKanjiComponents}
+    />
+  );
+}

--- a/src/options/KanjiReferenceSetting.tsx
+++ b/src/options/KanjiReferenceSetting.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'preact/hooks';
+
+import { DbLanguageId } from '../common/db-languages';
+import { useLocale } from '../common/i18n';
+import {
+  getReferenceLabelsForLang,
+  type ReferenceAbbreviation,
+} from '../common/refs';
+
+type Props = {
+  dictLang: DbLanguageId;
+  enabledReferences: Array<ReferenceAbbreviation>;
+  showKanjiComponents: boolean;
+  onToggleReference: (ref: ReferenceAbbreviation, value: boolean) => void;
+  onToggleKanjiComponents: (value: boolean) => void;
+};
+
+export function KanjiReferenceSetting(props: Props) {
+  const { t } = useLocale();
+  const lang = t('lang_tag');
+
+  const references = useMemo(() => {
+    return [
+      {
+        ref: 'kanjiComponents',
+        full: t('options_kanji_components'),
+      },
+      ...getReferenceLabelsForLang(props.dictLang, t),
+    ];
+  }, [props.dictLang, lang]);
+
+  const enabledReferences = useMemo(
+    () => new Set(props.enabledReferences),
+    [props.enabledReferences]
+  );
+
+  // We want to match the arrangement of references when they are displayed,
+  // that is, in a vertically flowing grid. See comments where we generate the
+  // popup styles for more explanation.
+  const gridTemplateRows = `repeat(${Math.ceil(
+    references.length / 2
+  )}, minmax(min-content, max-content))`;
+
+  return (
+    <div
+      class="section-content panel-section-grid"
+      style={{ gridTemplateRows }}
+    >
+      {references.map(({ ref, full }) => (
+        <div class="checkbox-row">
+          <input
+            type="checkbox"
+            id={`ref-${ref}`}
+            name={ref}
+            checked={
+              ref === 'kanjiComponents'
+                ? props.showKanjiComponents
+                : enabledReferences.has(ref as ReferenceAbbreviation)
+            }
+            onClick={(event) => {
+              const value = event.currentTarget.checked;
+              if (ref === 'kanjiComponents') {
+                props.onToggleKanjiComponents(value);
+              } else {
+                props.onToggleReference(ref as ReferenceAbbreviation, value);
+              }
+            }}
+          />
+          <label for={`ref-${ref}`}>{full}</label>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/options/KanjiReferenceSetting.tsx
+++ b/src/options/KanjiReferenceSetting.tsx
@@ -7,6 +7,8 @@ import {
   type ReferenceAbbreviation,
 } from '../common/refs';
 
+import { CheckboxRow } from './CheckboxRow';
+
 type Props = {
   dictLang: DbLanguageId;
   enabledReferences: Array<ReferenceAbbreviation>;
@@ -43,11 +45,11 @@ export function KanjiReferenceSetting(props: Props) {
 
   return (
     <div
-      class="section-content panel-section-grid"
+      class="firefox:mx-4 grid w-[95%] grid-cols-[minmax(250px,1fr)] gap-x-4 py-4 min-[500px]:grid-flow-col min-[500px]:grid-cols-[repeat(2,minmax(250px,1fr))]"
       style={{ gridTemplateRows }}
     >
       {references.map(({ ref, full }) => (
-        <div class="checkbox-row">
+        <CheckboxRow>
           <input
             type="checkbox"
             id={`ref-${ref}`}
@@ -67,7 +69,7 @@ export function KanjiReferenceSetting(props: Props) {
             }}
           />
           <label for={`ref-${ref}`}>{full}</label>
-        </div>
+        </CheckboxRow>
       ))}
     </div>
   );

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -1,16 +1,28 @@
-import { I18nProvider } from '../common/i18n';
+import type { RenderableProps } from 'preact';
+import { I18nProvider, useLocale } from '../common/i18n';
 import { getReleaseStage } from '../utils/release-stage';
+import { EmptyProps } from '../utils/type-helpers';
 
 import { DbStatus } from './DbStatus';
 import { useDb } from './use-db';
 
 export function OptionsPage() {
+  return (
+    <I18nProvider>
+      <OptionsPageInner />
+    </I18nProvider>
+  );
+}
+
+function OptionsPageInner() {
+  const { t } = useLocale();
   const { dbState, startDatabaseUpdate, cancelDatabaseUpdate, deleteDatabase } =
     useDb();
   const releaseStage = getReleaseStage();
 
   return (
-    <I18nProvider>
+    <>
+      <SectionHeading>{t('options_dictionary_data_heading')}</SectionHeading>
       <DbStatus
         dbState={dbState}
         devMode={releaseStage === 'development'}
@@ -18,6 +30,33 @@ export function OptionsPage() {
         onDeleteDb={deleteDatabase}
         onUpdateDb={startDatabaseUpdate}
       />
-    </I18nProvider>
+    </>
+  );
+}
+
+function SectionHeading(props: RenderableProps<EmptyProps>) {
+  // TODO: Once we converted all headings to Tailwind, we need to apply the
+  // special styling to the first heading in the section to remove its border
+  // and padding, and reduce the margin.
+  //
+  // For reference, the styles we use(d) for this are:
+  //
+  //  .section-header {
+  //    font-size: 1.46em;
+  //    font-weight: 300;
+  //    line-height: 1.3em;
+  //    margin: 8px 0;
+  //  }
+  //
+  //  .section-header:nth-of-type(n + 2) {
+  //    margin-top: 16px;
+  //    padding-top: 16px;
+  //    border-top: 1px solid lightgrey;
+  //  }
+  //
+  return (
+    <h1 class="mt-4 border-0 border-t border-solid border-t-gray-300 pt-4 text-2xl font-light">
+      {props.children}
+    </h1>
   );
 }

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -1,0 +1,23 @@
+import { I18nProvider } from '../common/i18n';
+import { getReleaseStage } from '../utils/release-stage';
+
+import { DbStatus } from './DbStatus';
+import { useDb } from './use-db';
+
+export function OptionsPage() {
+  const { dbState, startDatabaseUpdate, cancelDatabaseUpdate, deleteDatabase } =
+    useDb();
+  const releaseStage = getReleaseStage();
+
+  return (
+    <I18nProvider>
+      <DbStatus
+        dbState={dbState}
+        devMode={releaseStage === 'development'}
+        onCancelDbUpdate={cancelDatabaseUpdate}
+        onDeleteDb={deleteDatabase}
+        onUpdateDb={startDatabaseUpdate}
+      />
+    </I18nProvider>
+  );
+}

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -1,27 +1,64 @@
 import type { RenderableProps } from 'preact';
+import { useCallback } from 'preact/hooks';
+
+import type { Config } from '../common/config';
 import { I18nProvider, useLocale } from '../common/i18n';
+import { ReferenceAbbreviation } from '../common/refs';
 import { getReleaseStage } from '../utils/release-stage';
-import { EmptyProps } from '../utils/type-helpers';
+import type { EmptyProps } from '../utils/type-helpers';
 
 import { DbStatus } from './DbStatus';
+import { KanjiReferenceSetting } from './KanjiReferenceSetting';
 import { useDb } from './use-db';
+import { useConfigValue } from './use-config-value';
 
-export function OptionsPage() {
+type Props = {
+  config: Config;
+};
+
+export function OptionsPage(props: Props) {
   return (
     <I18nProvider>
-      <OptionsPageInner />
+      <OptionsPageInner {...props} />
     </I18nProvider>
   );
 }
 
-function OptionsPageInner() {
+function OptionsPageInner(props: Props) {
   const { t } = useLocale();
   const { dbState, startDatabaseUpdate, cancelDatabaseUpdate, deleteDatabase } =
     useDb();
   const releaseStage = getReleaseStage();
 
+  const dictLang = useConfigValue(props.config, 'dictLang');
+  const enabledReferences = useConfigValue(props.config, 'kanjiReferences');
+  const showKanjiComponents = useConfigValue(
+    props.config,
+    'showKanjiComponents'
+  );
+  const onToggleReference = useCallback(
+    (ref: ReferenceAbbreviation, value: boolean) => {
+      props.config.updateKanjiReferences({ [ref]: value });
+    },
+    [props.config]
+  );
+  const onToggleKanjiComponents = useCallback(
+    (value: boolean) => {
+      props.config.showKanjiComponents = value;
+    },
+    [props.config]
+  );
+
   return (
     <>
+      <SectionHeading>{t('options_kanji_dictionary_heading')}</SectionHeading>
+      <KanjiReferenceSetting
+        dictLang={dictLang}
+        enabledReferences={enabledReferences}
+        showKanjiComponents={showKanjiComponents}
+        onToggleReference={onToggleReference}
+        onToggleKanjiComponents={onToggleKanjiComponents}
+      />
       <SectionHeading>{t('options_dictionary_data_heading')}</SectionHeading>
       <DbStatus
         dbState={dbState}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -854,29 +854,3 @@ fieldset.bordered {
     color: hsl(45, 35.3%, 80%);
   }
 }
-
-/*
- * Grid layout panel
- */
-
-.panel-section-grid {
-  display: grid;
-  width: 95%;
-  grid-template-columns: repeat(2, minmax(250px, 1fr));
-  grid-column-gap: 1em;
-  grid-auto-flow: column;
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-:root.firefox .panel-section-grid {
-  margin-left: 16px;
-  margin-right: 16px;
-}
-
-/* Edge options window is tiny */
-@media (max-width: 500px) {
-  .panel-section-grid {
-    grid-template-columns: minmax(250px, 1fr);
-    grid-auto-flow: row;
-  }
-}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -670,19 +670,6 @@
           </ul>
         </div>
       </div>
-      <h1 class="section-header">__MSG_options_kanji_dictionary_heading__</h1>
-      <div class="section-content panel-section-grid" id="kanji-reference-list">
-        <div class="checkbox-row static">
-          <input
-            type="checkbox"
-            id="showKanjiComponents"
-            name="showKanjiComponents"
-          />
-          <label for="showKanjiComponents"
-            >__MSG_options_kanji_components__</label
-          >
-        </div>
-      </div>
       <div id="container"></div>
     </form>
     <!-- Common SVG symbols -->

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -683,7 +683,6 @@
           >
         </div>
       </div>
-      <h1 class="section-header">__MSG_options_dictionary_data_heading__</h1>
       <div id="container"></div>
     </form>
     <!-- Common SVG symbols -->

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -684,7 +684,7 @@
         </div>
       </div>
       <h1 class="section-header">__MSG_options_dictionary_data_heading__</h1>
-      <div id="db-summary-mount-point"></div>
+      <div id="container"></div>
     </form>
     <!-- Common SVG symbols -->
     <svg width="0" height="0" role="presentation">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -823,7 +823,10 @@ function createKanjiReferences() {
     }
   }
 
-  const referenceNames = getReferenceLabelsForLang(config.dictLang);
+  const referenceNames = getReferenceLabelsForLang(
+    config.dictLang,
+    browser.i18n.getMessage
+  );
   for (const { ref, full } of referenceNames) {
     const checkbox = html('input', {
       type: 'checkbox',

--- a/src/options/use-config-value.ts
+++ b/src/options/use-config-value.ts
@@ -1,0 +1,30 @@
+import { useSyncExternalStore } from 'preact/compat';
+import { useCallback, useRef } from 'preact/hooks';
+
+import { type ChangeCallback, Config } from '../common/config';
+
+export function useConfigValue<K extends keyof Config>(
+  config: Config,
+  key: K
+): Config[K] {
+  const snapshot = useRef(config[key]);
+
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const changeCallback: ChangeCallback = (changes) => {
+        if (Object.keys(changes).includes(key)) {
+          snapshot.current = config[key];
+          callback();
+        }
+      };
+
+      config.addChangeListener(changeCallback);
+      return () => config.removeChangeListener(changeCallback);
+    },
+    [config, key]
+  );
+
+  const getSnapshot = () => snapshot.current;
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/options/use-config-value.ts
+++ b/src/options/use-config-value.ts
@@ -1,5 +1,4 @@
-import { useSyncExternalStore } from 'preact/compat';
-import { useCallback, useRef } from 'preact/hooks';
+import { useEffect, useState } from 'preact/hooks';
 
 import { type ChangeCallback, Config } from '../common/config';
 
@@ -7,24 +6,18 @@ export function useConfigValue<K extends keyof Config>(
   config: Config,
   key: K
 ): Config[K] {
-  const snapshot = useRef(config[key]);
+  const [value, setValue] = useState<Config[K]>(config[key]);
 
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      const changeCallback: ChangeCallback = (changes) => {
-        if (Object.keys(changes).includes(key)) {
-          snapshot.current = config[key];
-          callback();
-        }
-      };
+  useEffect(() => {
+    const changeCallback: ChangeCallback = (changes) => {
+      if (Object.keys(changes).includes(key)) {
+        setValue(config[key]);
+      }
+    };
 
-      config.addChangeListener(changeCallback);
-      return () => config.removeChangeListener(changeCallback);
-    },
-    [config, key]
-  );
+    config.addChangeListener(changeCallback);
+    return () => config.removeChangeListener(changeCallback);
+  }, [config, key]);
 
-  const getSnapshot = () => snapshot.current;
-
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return value;
 }

--- a/src/options/use-db.ts
+++ b/src/options/use-db.ts
@@ -1,0 +1,142 @@
+import Bugsnag from '@birchill/bugsnag-zero';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
+import browser, { Runtime } from 'webextension-polyfill';
+
+import { JpdictState } from '../background/jpdict';
+import {
+  cancelDbUpdate,
+  DbStateUpdatedMessage,
+  deleteDb,
+  updateDb,
+} from '../common/db-listener-messages';
+import { isObject } from '../utils/is-object';
+
+const initialDbstate: JpdictState = {
+  words: {
+    state: 'init',
+    version: null,
+  },
+  kanji: {
+    state: 'init',
+    version: null,
+  },
+  radicals: {
+    state: 'init',
+    version: null,
+  },
+  names: {
+    state: 'init',
+    version: null,
+  },
+  updateState: { type: 'idle', lastCheck: null },
+};
+
+export function useDb(): {
+  dbState: JpdictState;
+  startDatabaseUpdate: () => void;
+  cancelDatabaseUpdate: () => void;
+  deleteDatabase: () => void;
+} {
+  const [dbState, setDbState] = useState<JpdictState>(initialDbstate);
+  const browserPortRef = useRef<Runtime.Port | undefined>(undefined);
+
+  useEffect(() => {
+    let browserPort = browser.runtime.connect(undefined, { name: 'options' });
+    browserPortRef.current = browserPort;
+
+    browserPort.onMessage.addListener((event: unknown) => {
+      if (isDbStateUpdatedMessage(event)) {
+        // For Runtime.Port.postMessage Chrome appears to serialize objects
+        // using JSON serialization (not structured cloned). As a result, any
+        // Date objects will be transformed into strings.
+        //
+        // Ideally we'd introduce a new type for these deserialized objects that
+        // converts `Date` to `Date | string` but that is likely to take a full
+        // day of TypeScript wrestling so instead we just manually reach into
+        // this object and convert the fields known to possibly contain dates
+        // into dates.
+        if (typeof event.state.updateState.lastCheck === 'string') {
+          event.state.updateState.lastCheck = new Date(
+            event.state.updateState.lastCheck
+          );
+        }
+        if (typeof event.state.updateError?.nextRetry === 'string') {
+          event.state.updateError.nextRetry = new Date(
+            event.state.updateError.nextRetry
+          );
+        }
+
+        setDbState(event.state);
+      }
+    });
+
+    // It's possible this might be disconnected on iOS which doesn't seem to
+    // keep inactive ports alive.
+    //
+    // Note that according to the docs, this should not be called when _we_ call
+    // disconnect():
+    //
+    //  https://developer.chrome.com/docs/extensions/mv3/messaging/#port-lifetime
+    //
+    // Nevertheless, we check that `browserPort` is not undefined before trying to
+    // re-connect just in case some browsers behave differently here.
+    browserPort.onDisconnect.addListener((port: Runtime.Port) => {
+      // Firefox annotates `port` with an `error` but Chrome does not.
+      const error =
+        isObject((port as any).error) &&
+        typeof (port as any).error.message === 'string'
+          ? (port as any).error.message
+          : browser.runtime.lastError;
+      Bugsnag.leaveBreadcrumb(
+        `Options page disconnected from background page: ${error}`
+      );
+
+      // Wait a moment and try to reconnect
+      setTimeout(() => {
+        try {
+          // Check that browserPort is still set to _something_. If it is
+          // undefined it probably means we are shutting down.
+          if (!browserPort) {
+            return;
+          }
+          browserPort = browser.runtime.connect(undefined, { name: 'options' });
+        } catch (e) {
+          void Bugsnag.notify(e);
+        }
+      }, 1000);
+    });
+
+    window.addEventListener('unload', () => {
+      browserPort?.disconnect();
+    });
+
+    return () => {
+      browserPort?.disconnect();
+      browserPortRef.current = undefined;
+    };
+  }, []);
+
+  const startDatabaseUpdate = useCallback(() => {
+    browserPortRef.current?.postMessage(updateDb());
+  }, []);
+
+  const cancelDatabaseUpdate = useCallback(() => {
+    browserPortRef.current?.postMessage(cancelDbUpdate());
+  }, []);
+
+  const deleteDatabase = useCallback(() => {
+    browserPortRef.current?.postMessage(deleteDb());
+  }, []);
+
+  return { dbState, startDatabaseUpdate, cancelDatabaseUpdate, deleteDatabase };
+}
+
+function isDbStateUpdatedMessage(
+  event: unknown
+): event is DbStateUpdatedMessage {
+  return (
+    isObject(event) &&
+    typeof (event as any).type === 'string' &&
+    (event as any).type === 'dbstateupdated'
+  );
+}


### PR DESCRIPTION
- chore: fix typo
- chore: move database listening to a hook
- chore: convert dictionary data heading to Preact/Tailwind
- fix: expose the correct name for kanji references when reporting changes
- chore: move reference rendering to a separate file
- chore: remove dependency on browser polyfill from refs.ts
- chore: convert kanji reference setting UI to Preact
- chore: simplify useConfigValue
- chore: convert kanji reference settings styles to Tailwind
