### PR TITLE
Various tweaks to the options page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/src/options/DbStatus.tsx
+++ b/src/options/DbStatus.tsx
@@ -211,7 +211,7 @@ function IdleStateSummary(props: {
 
   return (
     <DbSummaryContainer>
-      <div class="grid auto-cols-fr grid-flow-col grid-rows-[repeat(2,_auto)] gap-x-2 min-[500px]:gap-x-4">
+      <div class="grid auto-cols-fr grid-flow-col grid-rows-[repeat(2,_auto)] gap-x-2 sm:gap-x-4">
         {allMajorDataSeries.map((series) => {
           const versionInfo = props.dbState[series].version;
           return versionInfo ? (

--- a/src/options/KanjiReferenceSettings.fixture.tsx
+++ b/src/options/KanjiReferenceSettings.fixture.tsx
@@ -3,7 +3,7 @@ import { useSelect } from 'react-cosmos/client';
 
 import { DbLanguageId, dbLanguages } from '../common/db-languages';
 import { ReferenceAbbreviation } from '../common/refs';
-import { KanjiReferenceSetting } from './KanjiReferenceSetting';
+import { KanjiReferenceSettings } from './KanjiReferenceSettings';
 
 import './options.css';
 
@@ -31,7 +31,7 @@ export default function () {
   const [showKanjiComponents, setShowKanjiComponents] = useState(true);
 
   return (
-    <KanjiReferenceSetting
+    <KanjiReferenceSettings
       dictLang={dictLang}
       enabledReferences={enabledReferences}
       showKanjiComponents={showKanjiComponents}

--- a/src/options/KanjiReferenceSettings.tsx
+++ b/src/options/KanjiReferenceSettings.tsx
@@ -1,76 +1,42 @@
-import { useMemo } from 'preact/hooks';
+import { useCallback } from 'preact/hooks';
 
-import { DbLanguageId } from '../common/db-languages';
-import { useLocale } from '../common/i18n';
-import {
-  getReferenceLabelsForLang,
-  type ReferenceAbbreviation,
-} from '../common/refs';
+import type { Config } from '../common/config';
+import type { ReferenceAbbreviation } from '../common/refs';
 
-import { CheckboxRow } from './CheckboxRow';
+import { KanjiReferenceSettingsForm } from './KanjiReferenceSettingsForm';
+import { useConfigValue } from './use-config-value';
 
 type Props = {
-  dictLang: DbLanguageId;
-  enabledReferences: Array<ReferenceAbbreviation>;
-  showKanjiComponents: boolean;
-  onToggleReference: (ref: ReferenceAbbreviation, value: boolean) => void;
-  onToggleKanjiComponents: (value: boolean) => void;
+  config: Config;
 };
 
 export function KanjiReferenceSettings(props: Props) {
-  const { t } = useLocale();
-  const lang = t('lang_tag');
-
-  const references = useMemo(() => {
-    return [
-      {
-        ref: 'kanjiComponents',
-        full: t('options_kanji_components'),
-      },
-      ...getReferenceLabelsForLang(props.dictLang, t),
-    ];
-  }, [props.dictLang, lang]);
-
-  const enabledReferences = useMemo(
-    () => new Set(props.enabledReferences),
-    [props.enabledReferences]
+  const dictLang = useConfigValue(props.config, 'dictLang');
+  const enabledReferences = useConfigValue(props.config, 'kanjiReferences');
+  const showKanjiComponents = useConfigValue(
+    props.config,
+    'showKanjiComponents'
+  );
+  const onToggleReference = useCallback(
+    (ref: ReferenceAbbreviation, value: boolean) => {
+      props.config.updateKanjiReferences({ [ref]: value });
+    },
+    [props.config]
+  );
+  const onToggleKanjiComponents = useCallback(
+    (value: boolean) => {
+      props.config.showKanjiComponents = value;
+    },
+    [props.config]
   );
 
-  // We want to match the arrangement of references when they are displayed,
-  // that is, in a vertically flowing grid. See comments where we generate the
-  // popup styles for more explanation.
-  const gridTemplateRows = `repeat(${Math.ceil(
-    references.length / 2
-  )}, minmax(min-content, max-content))`;
-
   return (
-    <div
-      class="firefox:mx-4 grid w-[95%] grid-cols-[minmax(250px,1fr)] gap-x-4 py-4 min-[500px]:grid-flow-col min-[500px]:grid-cols-[repeat(2,minmax(250px,1fr))]"
-      style={{ gridTemplateRows }}
-    >
-      {references.map(({ ref, full }) => (
-        <CheckboxRow>
-          <input
-            type="checkbox"
-            id={`ref-${ref}`}
-            name={ref}
-            checked={
-              ref === 'kanjiComponents'
-                ? props.showKanjiComponents
-                : enabledReferences.has(ref as ReferenceAbbreviation)
-            }
-            onClick={(event) => {
-              const value = event.currentTarget.checked;
-              if (ref === 'kanjiComponents') {
-                props.onToggleKanjiComponents(value);
-              } else {
-                props.onToggleReference(ref as ReferenceAbbreviation, value);
-              }
-            }}
-          />
-          <label for={`ref-${ref}`}>{full}</label>
-        </CheckboxRow>
-      ))}
-    </div>
+    <KanjiReferenceSettingsForm
+      dictLang={dictLang}
+      enabledReferences={enabledReferences}
+      showKanjiComponents={showKanjiComponents}
+      onToggleReference={onToggleReference}
+      onToggleKanjiComponents={onToggleKanjiComponents}
+    />
   );
 }

--- a/src/options/KanjiReferenceSettings.tsx
+++ b/src/options/KanjiReferenceSettings.tsx
@@ -17,7 +17,7 @@ type Props = {
   onToggleKanjiComponents: (value: boolean) => void;
 };
 
-export function KanjiReferenceSetting(props: Props) {
+export function KanjiReferenceSettings(props: Props) {
   const { t } = useLocale();
   const lang = t('lang_tag');
 

--- a/src/options/KanjiReferenceSettingsForm.fixture.tsx
+++ b/src/options/KanjiReferenceSettingsForm.fixture.tsx
@@ -3,7 +3,7 @@ import { useSelect } from 'react-cosmos/client';
 
 import { DbLanguageId, dbLanguages } from '../common/db-languages';
 import { ReferenceAbbreviation } from '../common/refs';
-import { KanjiReferenceSettings } from './KanjiReferenceSettings';
+import { KanjiReferenceSettingsForm } from './KanjiReferenceSettingsForm';
 
 import './options.css';
 
@@ -31,7 +31,7 @@ export default function () {
   const [showKanjiComponents, setShowKanjiComponents] = useState(true);
 
   return (
-    <KanjiReferenceSettings
+    <KanjiReferenceSettingsForm
       dictLang={dictLang}
       enabledReferences={enabledReferences}
       showKanjiComponents={showKanjiComponents}

--- a/src/options/KanjiReferenceSettingsForm.tsx
+++ b/src/options/KanjiReferenceSettingsForm.tsx
@@ -45,7 +45,7 @@ export function KanjiReferenceSettingsForm(props: Props) {
 
   return (
     <div
-      class="firefox:mx-4 grid w-[95%] grid-cols-[minmax(250px,1fr)] gap-x-4 py-4 min-[500px]:grid-flow-col min-[500px]:grid-cols-[repeat(2,minmax(250px,1fr))]"
+      class="firefox:mx-4 grid w-[95%] grid-cols-[minmax(250px,1fr)] gap-x-4 py-4 sm:grid-flow-col sm:grid-cols-[repeat(2,minmax(250px,1fr))]"
       style={{ gridTemplateRows }}
     >
       {references.map(({ ref, full }) => (

--- a/src/options/KanjiReferenceSettingsForm.tsx
+++ b/src/options/KanjiReferenceSettingsForm.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from 'preact/hooks';
+
+import { DbLanguageId } from '../common/db-languages';
+import { useLocale } from '../common/i18n';
+import {
+  getReferenceLabelsForLang,
+  type ReferenceAbbreviation,
+} from '../common/refs';
+
+import { CheckboxRow } from './CheckboxRow';
+
+type Props = {
+  dictLang: DbLanguageId;
+  enabledReferences: Array<ReferenceAbbreviation>;
+  showKanjiComponents: boolean;
+  onToggleReference: (ref: ReferenceAbbreviation, value: boolean) => void;
+  onToggleKanjiComponents: (value: boolean) => void;
+};
+
+export function KanjiReferenceSettingsForm(props: Props) {
+  const { t } = useLocale();
+  const lang = t('lang_tag');
+
+  const references = useMemo(() => {
+    return [
+      {
+        ref: 'kanjiComponents',
+        full: t('options_kanji_components'),
+      },
+      ...getReferenceLabelsForLang(props.dictLang, t),
+    ];
+  }, [props.dictLang, lang]);
+
+  const enabledReferences = useMemo(
+    () => new Set(props.enabledReferences),
+    [props.enabledReferences]
+  );
+
+  // We want to match the arrangement of references when they are displayed,
+  // that is, in a vertically flowing grid. See comments where we generate the
+  // popup styles for more explanation.
+  const gridTemplateRows = `repeat(${Math.ceil(
+    references.length / 2
+  )}, minmax(min-content, max-content))`;
+
+  return (
+    <div
+      class="firefox:mx-4 grid w-[95%] grid-cols-[minmax(250px,1fr)] gap-x-4 py-4 min-[500px]:grid-flow-col min-[500px]:grid-cols-[repeat(2,minmax(250px,1fr))]"
+      style={{ gridTemplateRows }}
+    >
+      {references.map(({ ref, full }) => (
+        <CheckboxRow>
+          <input
+            type="checkbox"
+            id={`ref-${ref}`}
+            name={ref}
+            checked={
+              ref === 'kanjiComponents'
+                ? props.showKanjiComponents
+                : enabledReferences.has(ref as ReferenceAbbreviation)
+            }
+            onClick={(event) => {
+              const value = event.currentTarget.checked;
+              if (ref === 'kanjiComponents') {
+                props.onToggleKanjiComponents(value);
+              } else {
+                props.onToggleReference(ref as ReferenceAbbreviation, value);
+              }
+            }}
+          />
+          <label for={`ref-${ref}`}>{full}</label>
+        </CheckboxRow>
+      ))}
+    </div>
+  );
+}

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -6,7 +6,7 @@ import { ReferenceAbbreviation } from '../common/refs';
 import { getReleaseStage } from '../utils/release-stage';
 
 import { DbStatus } from './DbStatus';
-import { KanjiReferenceSetting } from './KanjiReferenceSetting';
+import { KanjiReferenceSettings } from './KanjiReferenceSettings';
 import { SectionHeading } from './SectionHeading';
 import { useDb } from './use-db';
 import { useConfigValue } from './use-config-value';
@@ -51,7 +51,7 @@ function OptionsPageInner(props: Props) {
   return (
     <>
       <SectionHeading>{t('options_kanji_dictionary_heading')}</SectionHeading>
-      <KanjiReferenceSetting
+      <KanjiReferenceSettings
         dictLang={dictLang}
         enabledReferences={enabledReferences}
         showKanjiComponents={showKanjiComponents}

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -1,14 +1,13 @@
-import type { RenderableProps } from 'preact';
 import { useCallback } from 'preact/hooks';
 
 import type { Config } from '../common/config';
 import { I18nProvider, useLocale } from '../common/i18n';
 import { ReferenceAbbreviation } from '../common/refs';
 import { getReleaseStage } from '../utils/release-stage';
-import type { EmptyProps } from '../utils/type-helpers';
 
 import { DbStatus } from './DbStatus';
 import { KanjiReferenceSetting } from './KanjiReferenceSetting';
+import { SectionHeading } from './SectionHeading';
 import { useDb } from './use-db';
 import { useConfigValue } from './use-config-value';
 
@@ -68,32 +67,5 @@ function OptionsPageInner(props: Props) {
         onUpdateDb={startDatabaseUpdate}
       />
     </>
-  );
-}
-
-function SectionHeading(props: RenderableProps<EmptyProps>) {
-  // TODO: Once we converted all headings to Tailwind, we need to apply the
-  // special styling to the first heading in the section to remove its border
-  // and padding, and reduce the margin.
-  //
-  // For reference, the styles we use(d) for this are:
-  //
-  //  .section-header {
-  //    font-size: 1.46em;
-  //    font-weight: 300;
-  //    line-height: 1.3em;
-  //    margin: 8px 0;
-  //  }
-  //
-  //  .section-header:nth-of-type(n + 2) {
-  //    margin-top: 16px;
-  //    padding-top: 16px;
-  //    border-top: 1px solid lightgrey;
-  //  }
-  //
-  return (
-    <h1 class="mt-4 border-0 border-t border-solid border-t-gray-300 pt-4 text-2xl font-light">
-      {props.children}
-    </h1>
   );
 }

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -1,15 +1,11 @@
-import { useCallback } from 'preact/hooks';
-
 import type { Config } from '../common/config';
 import { I18nProvider, useLocale } from '../common/i18n';
-import { ReferenceAbbreviation } from '../common/refs';
 import { getReleaseStage } from '../utils/release-stage';
 
 import { DbStatus } from './DbStatus';
 import { KanjiReferenceSettings } from './KanjiReferenceSettings';
 import { SectionHeading } from './SectionHeading';
 import { useDb } from './use-db';
-import { useConfigValue } from './use-config-value';
 
 type Props = {
   config: Config;
@@ -29,35 +25,10 @@ function OptionsPageInner(props: Props) {
     useDb();
   const releaseStage = getReleaseStage();
 
-  const dictLang = useConfigValue(props.config, 'dictLang');
-  const enabledReferences = useConfigValue(props.config, 'kanjiReferences');
-  const showKanjiComponents = useConfigValue(
-    props.config,
-    'showKanjiComponents'
-  );
-  const onToggleReference = useCallback(
-    (ref: ReferenceAbbreviation, value: boolean) => {
-      props.config.updateKanjiReferences({ [ref]: value });
-    },
-    [props.config]
-  );
-  const onToggleKanjiComponents = useCallback(
-    (value: boolean) => {
-      props.config.showKanjiComponents = value;
-    },
-    [props.config]
-  );
-
   return (
     <>
       <SectionHeading>{t('options_kanji_dictionary_heading')}</SectionHeading>
-      <KanjiReferenceSettings
-        dictLang={dictLang}
-        enabledReferences={enabledReferences}
-        showKanjiComponents={showKanjiComponents}
-        onToggleReference={onToggleReference}
-        onToggleKanjiComponents={onToggleKanjiComponents}
-      />
+      <KanjiReferenceSettings config={props.config} />
       <SectionHeading>{t('options_dictionary_data_heading')}</SectionHeading>
       <DbStatus
         dbState={dbState}

--- a/src/options/SectionHeading.tsx
+++ b/src/options/SectionHeading.tsx
@@ -1,0 +1,29 @@
+import type { RenderableProps } from 'preact';
+import type { EmptyProps } from '../utils/type-helpers';
+
+export function SectionHeading(props: RenderableProps<EmptyProps>) {
+  // TODO: Once we have converted all headings to Tailwind, we need to apply the
+  // special styling to the first heading in the section to remove its border
+  // and padding, and reduce the margin.
+  //
+  // For reference, the styles we use(d) for this are:
+  //
+  //  .section-header {
+  //    font-size: 1.46em;
+  //    font-weight: 300;
+  //    line-height: 1.3em;
+  //    margin: 8px 0;
+  //  }
+  //
+  //  .section-header:nth-of-type(n + 2) {
+  //    margin-top: 16px;
+  //    padding-top: 16px;
+  //    border-top: 1px solid lightgrey;
+  //  }
+  //
+  return (
+    <h1 class="mt-4 border-0 border-t border-solid border-t-gray-300 pt-4 text-2xl font-light">
+      {props.children}
+    </h1>
+  );
+}

--- a/src/options/tailwind.config.js
+++ b/src/options/tailwind.config.js
@@ -63,6 +63,13 @@ export default {
         purple: colors.violet,
       },
     },
+    screens: {
+      // This breakpoint corresponds to a point between the width of a mobile
+      // device the width of the Firefox settings screen.
+      //
+      // The default value of 640px is wider than the Firefox settings screen.
+      sm: '500px',
+    },
   },
   plugins: [
     plugin(({ addVariant }) => {


### PR DESCRIPTION
- chore: move SectionHeading to a separate file
- chore: rename KanjiReferenceSettingto KanjiReferenceSettings
- chore: move config bindings to separate wrapper
- chore: drop .vscode files
- chore: setup custom breakpoint for options screen
