### PR TITLE
Fix overlapping assignment of 'x' key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ app.
 - Fixed the popup changing width in some cases (e.g. when tabs are hidden and
   scrollbars are configured to always show)
   ([#1314](https://github.com/birchill/10ten-ja-reader/issues/1314)).
-- Make the `x` key close the popup if it is configured to _both_ close it and
-  expand it.
+- Added handling to avoid the <kbd>x</kbd> key being assigned to both closing
+  the popup _and_ expanding it.
 - Fixed recognition of words that end in half-width numerals like 小1.
 - Added parsing for ill-formed numbers like 39,800万円.
 - Made the options page show up in a new tab on Edge.

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -382,7 +382,7 @@ export class Config {
 
   set canHover(value: boolean) {
     const storedSetting = this.settings.localSettings?.canHover;
-    if (storedSetting === value) {
+    if (storedSetting === value || (storedSetting === undefined && value)) {
       return;
     }
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -746,6 +746,26 @@ export class Config {
       }
     }
 
+    // When we first released the `expandPopup` key ('x') we didn't notice
+    // that it was already possible to assign 'x' to `closePopup`.
+    //
+    // We _could_ try to make it so that if you assign 'x' to `expandPopup` we
+    // remove it from `closePopup`. But it might be slightly more useful to
+    // allow it to be assigned to both and simply report it as being assigned to
+    // `closePopup` in that case.
+    //
+    // That has the advantages that:
+    //
+    // 1. If you go to enable it for `closePopup` and notice that doing so
+    //    clears it from `expandPopup`, you can just untick it from `closePopup`
+    //    and it will automatically be restored to `expandPopup`.
+    //
+    // 2. We need to handle the case when they're both selected anyway since
+    //    it's already possible to get it into that state in a released version.
+    if (keys.expandPopup.includes('x') && keys.closePopup.includes('x')) {
+      keys.expandPopup = keys.expandPopup.filter((k) => k !== 'x');
+    }
+
     return keys;
   }
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1167,20 +1167,14 @@ export class ContentHandler {
       }
     } else if (this.copyState.kind !== 'inactive' && key === 'ESC') {
       this.exitCopyMode();
+    } else if (expandPopup.includes(key)) {
+      this.expandPopup();
     }
     // This needs to come _after_ the above check so that if the user has
     // configured Escape to close the popup but they are in copy mode, we first
     // escape copy mode (and if they press it a second time we close the popup).
     else if (closePopup.includes(key)) {
       this.clearResult();
-    }
-    // This needs to come after the check for a close popup key because that
-    // feature came first and allows a user to configure 'x' to close the popup.
-    //
-    // If 'x' ends up being set for _both_ closing the popup and expanding it,
-    // we should make it close the popup.
-    else if (expandPopup.includes(key)) {
-      this.expandPopup();
     } else if (
       pinPopup.includes(key) &&
       // We don't want to detect a pin keystroke if we are still in the ghost

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1446,7 +1446,7 @@ export class ContentHandler {
 
           let iframeOriginPoint;
           if (!iframe) {
-            console.warn("Couldn't find iframe element");
+            console.warn("[10ten-ja-reader] Couldn't find iframe element");
             // Just use the top-left corner since that's probably better than
             // not showing the popup at all.
             iframeOriginPoint = { x: 0, y: 0 };
@@ -1623,7 +1623,7 @@ export class ContentHandler {
     if (!this.isTopMostWindow()) {
       console.assert(
         trigger === 'keyboard',
-        "We probably should't be receiving touch or mouse events in the iframe"
+        "[10ten-ja-reader] We probably should't be receiving touch or mouse events in the iframe"
       );
       void browser.runtime.sendMessage({ type: 'top:enterCopyMode' });
       return;
@@ -1699,7 +1699,7 @@ export class ContentHandler {
 
   private getCopyEntry(): CopyEntry | null {
     if (this.copyState.kind !== 'active') {
-      console.error('Expected to be in copy mode');
+      console.error('[10ten-ja-reader] Expected to be in copy mode');
       return null;
     }
 
@@ -2499,7 +2499,7 @@ export class ContentHandler {
     } = {}
   ) {
     if (!this.isTopMostWindow()) {
-      console.warn('Called updatePopup within iframe');
+      console.warn('[10ten-ja-reader] Called updatePopup within iframe');
       return;
     }
 


### PR DESCRIPTION
- fix: handle overlapping assignment of x key properly
- chore: add extension name to a few console messages
- fix: ignore redundant changes to canHover setting
