### PR TITLE
Show search-only headwords when they are a direct match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ app.
 - Made matches on search-only headwords show the search-only version too
   (e.g. 磨ガラス, ペイチン)
   ([#1361](https://github.com/birchill/10ten-ja-reader/issues/1361)).
+- Hid the "usually kana" annotation when no kanji headwords are shown
+  (also [#1361](https://github.com/birchill/10ten-ja-reader/issues/1361)).
 
 ## [1.15.1] - 2023-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ app.
   <kbd>Delete</kbd>, <kbd>Up</kbd>, <kbd>Down</kbd>, <kbd>Left</kbd>,
   and <kbd>Right</kbd>.
 - Made it possible to clear the toggle key in Firefox/Thunderbird.
+- Made matches on search-only headwords show the search-only version too
+  (e.g. 磨ガラス, ペイチン)
+  ([#1361](https://github.com/birchill/10ten-ja-reader/issues/1361)).
 
 ## [1.15.1] - 2023-09-03
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -42,7 +42,7 @@
     <option value="value2" selected>塩</option>
     <option value="value3">味噌</option>
   </select>
-  <input type="checkbox" id="ネギなし" name="other" value="ネギなし" />
+  <input id="ネギなし" name="other" type="checkbox" value="ネギなし" />
   <label for="ネギなし">ネギ抜き</label>
   <div contenteditable>
     これはcontenteditableのやつだよ<br />
@@ -166,6 +166,12 @@
     <li>２四𠔼歩</li>
     <li>２四𠔼歩</li>
     <li>８三↑</li>
+  </ul>
+
+  <h3>Search-only match tests</h3>
+  <ul>
+    <li>磨ガラス</li>
+    <li>ペイチン</li>
   </ul>
 
   <h3>Shadow DOM tests (Blink/WebKit only)</h3>

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -174,6 +174,16 @@
     <li>ペイチン</li>
   </ul>
 
+  <h3>Kana-only tests</h3>
+  <ul>
+    <li>
+      はにかむ (Should <i><b>not</b></i> show "usually kana")
+    </li>
+    <li>含羞む (<i>Should</i> show "usually kana")</li>
+    <li>ほっきょくぐま (<i>Should</i> show "usually kana")</li>
+    <li>北極熊 (<i>Should</i> show "usually kana")</li>
+  </ul>
+
   <h3>Shadow DOM tests (Blink/WebKit only)</h3>
   <script>
     class MyElement extends HTMLElement {


### PR DESCRIPTION
- fix: show direct matches on search-only headwords
- fix: hide "usually kana" annotation when there are no kanji
