### PR TITLE
Convert enable tap to lookup setting to Preact/Tailwind

### DIFF
--- a/src/options/KanjiReferenceSettingsForm.tsx
+++ b/src/options/KanjiReferenceSettingsForm.tsx
@@ -68,7 +68,9 @@ export function KanjiReferenceSettingsForm(props: Props) {
               }
             }}
           />
-          <label for={`ref-${ref}`}>{full}</label>
+          <label class="cursor-pointer select-none" for={`ref-${ref}`}>
+            {full}
+          </label>
         </CheckboxRow>
       ))}
     </div>

--- a/src/options/PopupInteractivitySettings.tsx
+++ b/src/options/PopupInteractivitySettings.tsx
@@ -2,20 +2,28 @@ import { useCallback } from 'preact/hooks';
 
 import type { Config } from '../common/config';
 import { TabDisplay } from '../common/content-config-params';
-import { useLocale } from '../common/i18n';
+import { useHasTouch } from '../utils/use-has-touch';
 
-import { TabDisplayRadio } from './TabDisplayRadio';
 import { useConfigValue } from './use-config-value';
+import { PopupInteractivitySettingsForm } from './PopupInteractivitySettingsForm';
 
 type Props = {
   config: Config;
 };
 
 export function PopupInteractivitySettings(props: Props) {
-  const { t } = useLocale();
-  const tabDisplay = useConfigValue(props.config, 'tabDisplay');
+  const hasTouch = useHasTouch();
   const theme = useConfigValue(props.config, 'popupStyle');
 
+  const enableTapLookup = useConfigValue(props.config, 'enableTapLookup');
+  const onChangeEnableTapLookup = useCallback(
+    (value: boolean) => {
+      props.config.enableTapLookup = value;
+    },
+    [props.config]
+  );
+
+  const tabDisplay = useConfigValue(props.config, 'tabDisplay');
   const onChangeTabDisplay = useCallback(
     (value: TabDisplay) => {
       props.config.tabDisplay = value;
@@ -24,16 +32,13 @@ export function PopupInteractivitySettings(props: Props) {
   );
 
   return (
-    <>
-      <p>{t('options_tab_position_label')}</p>
-      <TabDisplayRadio
-        onChange={onChangeTabDisplay}
-        theme={theme}
-        value={tabDisplay}
-      />
-      {/* TODO: This should go _before_ the options_tab_position_label paragraph
-          once we migrate the other content into this component. */}
-      <div class="h-4" />
-    </>
+    <PopupInteractivitySettingsForm
+      enableTapLookup={enableTapLookup}
+      hasTouch={hasTouch}
+      onChangeEnableTapLookup={onChangeEnableTapLookup}
+      onChangeTabDisplay={onChangeTabDisplay}
+      tabDisplay={tabDisplay}
+      theme={theme}
+    />
   );
 }

--- a/src/options/PopupInteractivitySettingsForm.fixture.tsx
+++ b/src/options/PopupInteractivitySettingsForm.fixture.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'preact/hooks';
+import { useSelect, useValue } from 'react-cosmos/client';
+
+import { PopupInteractivitySettingsForm } from './PopupInteractivitySettingsForm';
+import { TabDisplay } from '../common/content-config-params';
+
+import './options.css';
+
+export default function () {
+  const [hasTouch] = useValue<boolean>('Touch enabled?', {
+    defaultValue: true,
+  });
+  const [enableTapLookup, setEnableTapLookup] = useState<boolean>(true);
+  const [tabDisplay, setTabDisplay] = useState<TabDisplay>('left');
+  const [theme] = useSelect<string>('theme', {
+    options: ['default', 'light', 'blue', 'lightblue', 'black', 'yellow'],
+  });
+
+  return (
+    <PopupInteractivitySettingsForm
+      enableTapLookup={enableTapLookup}
+      hasTouch={hasTouch}
+      onChangeEnableTapLookup={setEnableTapLookup}
+      onChangeTabDisplay={setTabDisplay}
+      tabDisplay={tabDisplay}
+      theme={theme}
+    />
+  );
+}

--- a/src/options/PopupInteractivitySettingsForm.tsx
+++ b/src/options/PopupInteractivitySettingsForm.tsx
@@ -1,0 +1,50 @@
+import type { JSX } from 'preact';
+
+import { TabDisplay } from '../common/content-config-params';
+import { useLocale } from '../common/i18n';
+import { CheckboxRow } from './CheckboxRow';
+import { TabDisplayRadio } from './TabDisplayRadio';
+
+type Props = {
+  enableTapLookup: boolean;
+  hasTouch: boolean;
+  onChangeEnableTapLookup: (value: boolean) => void;
+  onChangeTabDisplay: (value: TabDisplay) => void;
+  tabDisplay: TabDisplay;
+  theme: string;
+};
+
+export function PopupInteractivitySettingsForm(props: Props) {
+  const { t } = useLocale();
+
+  return (
+    <>
+      {props.hasTouch && (
+        <div class="mb-8">
+          <CheckboxRow>
+            <input
+              checked={props.enableTapLookup}
+              id="enableTapLookup"
+              name="enableTapLookup"
+              onClick={(event: JSX.TargetedEvent<HTMLInputElement>) => {
+                props.onChangeEnableTapLookup(event.currentTarget.checked);
+              }}
+              type="checkbox"
+            />
+            <label class="cursor-pointer select-none" for="enableTapLookup">
+              {t('options_touch_enable_tap_lookup')}
+            </label>
+          </CheckboxRow>
+        </div>
+      )}
+      <p>{t('options_tab_position_label')}</p>
+      <TabDisplayRadio
+        onChange={props.onChangeTabDisplay}
+        theme={props.theme}
+        value={props.tabDisplay}
+      />
+      {/* TODO: Drop this one we move this inside a suitable block. */}
+      <div class="h-4" />
+    </>
+  );
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -77,14 +77,6 @@ body {
   }
 }
 
-.needs-touch {
-  display: none;
-}
-
-.has-touch .needs-touch {
-  display: block;
-}
-
 /*
  * Container style
  */
@@ -621,8 +613,4 @@ fieldset.bordered {
     background: #102a76;
     color: #dbe9fb;
   }
-}
-
-#touch-interactivity-section {
-  margin-top: 12px;
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -391,20 +391,6 @@
             </div>
           </fieldset>
         </div>
-        <div id="touch-interactivity-section" class="needs-touch">
-          <div class="checkbox-row">
-            <input
-              id="enableTapLookup"
-              name="enableTapLookup"
-              type="checkbox"
-            />
-            <label for="enableTapLookup"
-              >__MSG_options_touch_enable_tap_lookup__<span class="new-badge"
-                >__MSG_options_new_badge_text__</span
-              ></label
-            >
-          </div>
-        </div>
       </div>
       <div id="container"></div>
     </form>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -11,7 +11,6 @@ import {
 import { renderStar } from '../content/popup/icons';
 import { startBugsnag } from '../utils/bugsnag';
 import { html } from '../utils/builder';
-import { isTouchDevice } from '../utils/device';
 import { empty } from '../utils/dom-utils';
 import {
   isChromium,
@@ -47,9 +46,6 @@ function completeForm() {
   }
   if (isSafari()) {
     document.documentElement.classList.add('safari');
-  }
-  if (isTouchDevice()) {
-    document.documentElement.classList.add('has-touch');
   }
 
   // Pop-up
@@ -182,12 +178,6 @@ function completeForm() {
       config.popupInteractive = popupInteractive === 'enable';
     });
   }
-
-  document
-    .getElementById('enableTapLookup')!
-    .addEventListener('click', (event) => {
-      config.enableTapLookup = (event.target as HTMLInputElement).checked;
-    });
 }
 
 function renderPopupStyleSelect() {
@@ -378,7 +368,6 @@ function fillVals() {
     ? 'enable'
     : 'disable';
   optform.popupStyle.value = config.popupStyle;
-  optform.enableTapLookup.checked = config.enableTapLookup;
   optform.toolbarIcon.value = config.toolbarIcon;
 }
 

--- a/src/utils/use-has-touch.ts
+++ b/src/utils/use-has-touch.ts
@@ -1,0 +1,21 @@
+import { useEffect, useMemo, useState } from 'preact/hooks';
+
+import { isTouchDevice } from './device';
+
+export function useHasTouch(): boolean {
+  const mql = useMemo(() => window.matchMedia('(any-pointer:coarse)'), []);
+  const [hasCoarsePointer, setHasCoarsePointer] = useState(mql.matches);
+
+  useEffect(() => {
+    const onMqlChange = (evt: MediaQueryListEvent) => {
+      setHasCoarsePointer(evt.matches);
+    };
+
+    mql.addEventListener('change', onMqlChange);
+    return () => {
+      mql.removeEventListener('change', onMqlChange);
+    };
+  }, []);
+
+  return useMemo(() => isTouchDevice(), [hasCoarsePointer]);
+}


### PR DESCRIPTION
- chore: convert enable tap lookup setting to Preact/Tailwind
- fix: make double-clicking kanji reference labels not select the text
