### PR TITLE
fix: ignore redundant mousedown/mouseup events on the puck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ app.
 - Fixed the popup changing width in some cases (e.g. when tabs are hidden and
   scrollbars are configured to always show)
   ([#1314](https://github.com/birchill/10ten-ja-reader/issues/1314)).
+- (Firefox) Made the lookup puck handle taps and double-taps correctly on
+  Firefox for Android.
 - Added handling to avoid the <kbd>x</kbd> key being assigned to both closing
   the popup _and_ expanding it.
 - Fixed recognition of words that end in half-width numerals like 小1.

--- a/src/content/puck.ts
+++ b/src/content/puck.ts
@@ -655,10 +655,7 @@ export class LookupPuck {
       // Carry across the timeout from 'firstclick', as we still want to
       // transition back to 'idle' if no 'pointerdown' event came within
       // the hysteresis period of the preceding 'firstclick' state.
-      this.clickState = {
-        ...this.clickState,
-        kind: 'secondpointerdown',
-      };
+      this.clickState = { ...this.clickState, kind: 'secondpointerdown' };
     }
 
     event.preventDefault();
@@ -687,10 +684,19 @@ export class LookupPuck {
   // detecting the second tap of a double-tap gesture.
   //
   // When the pointer events are _not_ swallowed, because we call preventDefault
-  // on the pointerdown / pointerup events, we these functions should never be
+  // on the pointerdown / pointerup events, these functions should never be
   // called.
 
   private readonly onPuckMouseDown = (event: MouseEvent) => {
+    // This is only needed for iOS Safari and on Firefox for Android, calling
+    // preventDefault on a pointerdown event will _not_ prevent it from
+    // triggering subsequent mousedown/mouseup events (see
+    // https://codepen.io/birtles/pen/rNPKNQJ) so we should _not_ run this code
+    // on platforms other than iOS.
+    if (!isIOS()) {
+      return;
+    }
+
     if (this.enabledState === 'disabled' || !this.puck) {
       return;
     }
@@ -726,6 +732,15 @@ export class LookupPuck {
   };
 
   private readonly onPuckMouseUp = (event: MouseEvent) => {
+    // This is only needed for iOS Safari and on Firefox for Android, calling
+    // preventDefault on a pointerdown event will _not_ prevent it from
+    // triggering subsequent mousedown/mouseup events (see
+    // https://codepen.io/birtles/pen/rNPKNQJ) so we should _not_ run this code
+    // on platforms other than iOS.
+    if (!isIOS()) {
+      return;
+    }
+
     if (this.enabledState === 'disabled' || !this.puck) {
       return;
     }
@@ -1075,15 +1090,15 @@ export class LookupPuck {
         // We've tried everything to avoid this (touch-action: none,
         // -webkit-user-select: none, etc. etc.) but it just sometimes does it.
         //
-        // Furthermore, when debugging, after about ~1hr or so it will somtimes
+        // Furthermore, when debugging, after about ~1hr or so it will sometimes
         // _stop_ eating these events, leading you to believe you've fixed it
         // only for it to start eating them again a few minutes later.
         //
-        // However, in this case it sill dispatches _mouse_ events so we listen
+        // However, in this case it still dispatches _mouse_ events so we listen
         // to them and trigger the necessary state transitions when needed.
         //
         // Note that the mere _presence_ of the mousedown handler is also needed
-        // to prevent double-tap being interpreted as a zoon.
+        // to prevent double-tap being interpreted as a zoom.
         this.puck.addEventListener('mousedown', this.onPuckMouseDown);
         this.puck.addEventListener('mouseup', this.onPuckMouseUp);
       }


### PR DESCRIPTION
See Codepen: https://codepen.io/birtles/pen/rNPKNQJ

In iOS Safari, if you call `preventDefault` on a `pointerdown` event you
will no longer get a subsequent `mousedown` / `mouseup`.
Calling `stopPropagation` appears to have no effect.

Conversely, in Chrome for Android, calling `stopPropagation` on a
`pointerdown` event will mean we no longer get a `mousedown` / `mouseup`
event but calling `preventDefault` will have no effect.
On Desktop it behaves the same as Safari.

Looks like Chrome for Android has a bug here for iframes however:
https://bugs.chromium.org/p/chromium/issues/detail?id=1016974

In Firefox for Android neither seems to have any effect. On Desktop, it
behaves the same as Safari.

I'll concede that this is the probably first time in history Safari for
iOS has actually done the right thing.

However, we run into trouble because we have these `mousedown`/`mouseup`
handlers set up because iOS so often does the wrong thing and eats
certain pointer events.

In Firefox for Android since calling `preventDefault` on the
`pointerdown` event doesn't suppress the subsequent
`mousedown`/`mouseup` events, if we run them as usual we'll end up
seeing a double-tap when there was only a single one.

This patch makes us ignore such events on platforms other than iOS
(where they're not needed).
