### PR TITLE
fix: check that the cursor is inside a textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ app.
   <kbd>PageUp</kbd>, <kbd>PageDown</kbd>, <kbd>Space</kbd>, <kbd>Insert</kbd>,
   <kbd>Delete</kbd>, <kbd>Up</kbd>, <kbd>Down</kbd>, <kbd>Left</kbd>,
   and <kbd>Right</kbd>.
+- Fixed lookup misbehaving on Firefox with `<textarea>`s with `display: block`
+  such as on pastebin.com
+  ([#1403](https://github.com/birchill/10ten-ja-reader/issues/1403)).
 - Made it possible to clear the toggle key in Firefox/Thunderbird.
 - Made matches on search-only headwords show the search-only version too
   (e.g. 磨ガラス, ペイチン)

--- a/src/content/get-cursor-position.ts
+++ b/src/content/get-cursor-position.ts
@@ -178,7 +178,21 @@ function getCursorPositionForElement({
 
   // If the position is in a text input element or Google Docs element return it
   // immediately.
-  if (isTextInputPosition(position) || isGdocsOverlayPosition(position)) {
+  if (isTextInputPosition(position)) {
+    // For a textarea we still need to check it overlaps since at least in
+    // Firefox, if it is display: block, caretPositionFromPoint might return it
+    // even when the point is outside the element.
+    //
+    // And although we've never encountered such a case, we should probably
+    // check that the element is visible too.
+    return positionIntersectsPoint(position, point) &&
+      isVisible(position.offsetNode)
+      ? position
+      : null;
+  }
+
+  // For Google Docs, presumably the element is overlapping and visible.
+  if (isGdocsOverlayPosition(position)) {
     return position;
   }
 

--- a/tests/get-text.test.ts
+++ b/tests/get-text.test.ts
@@ -1498,7 +1498,7 @@ describe('getTextAtPoint', () => {
     assertTextResultEqual(result, 'いうえお', [textAreaNode, 1, 5]);
   });
 
-  it('should NOT report results in textarea elements when the mouse is far away', () => {
+  it('should NOT report results in textarea elements when at the end', () => {
     testDiv.innerHTML = '<textarea cols=80>あいうえお</textarea>';
     const textAreaNode = testDiv.firstChild as HTMLTextAreaElement;
 
@@ -1507,6 +1507,24 @@ describe('getTextAtPoint', () => {
     const bbox = textAreaNode.getBoundingClientRect();
 
     const result = getTextAtPoint({ point: { x: bbox.right - 10, y: 5 } });
+
+    assert.strictEqual(result, null);
+  });
+
+  it('should NOT report results in textarea elements when the mouse is outside', () => {
+    testDiv.innerHTML = '<textarea cols=80>あいうえお</textarea>';
+    const textAreaNode = testDiv.firstChild as HTMLTextAreaElement;
+
+    // The display: block part is important here since it will cause
+    // caretPositionFromPoint to return the element even if it doesn't overlap.
+    //
+    // This is is why the textarea on pastebin.com was broken.
+    textAreaNode.style.display = 'block';
+    textAreaNode.style.marginLeft = '100px';
+    textAreaNode.style.fontSize = '20px';
+    const bbox = textAreaNode.getBoundingClientRect();
+
+    const result = getTextAtPoint({ point: { x: bbox.left - 50, y: 5 } });
 
     assert.strictEqual(result, null);
   });


### PR DESCRIPTION
Minimal test case:

```html
<!doctype html>
<html>
<head>
<meta charset=utf-8>
<style type="text/css">
.container {
  margin: 0 auto;
  max-width: 1340px;
}
.textarea {
  display: block;
  width: 100%;
  height: 300px;
}
</style>
</head>
<body>
  <div class="container">
    <textarea class="textarea">テスト</textarea>
  </div>
</html>
```

As for the updated title for one of the existing test cases, this
hopefully reflects what it was originally introduced to test here:

https://github.com/birchill/10ten-ja-reader/commit/06797fa4c4673831707d53b089c13b45e220aad9

Fixes #1403.
