### PR TITLE
Various fixes to the Mac shortcut key setting

### DIFF
--- a/src/options/KeyboardSettings.tsx
+++ b/src/options/KeyboardSettings.tsx
@@ -2,7 +2,7 @@ import Bugsnag from '@birchill/bugsnag-zero';
 import { useCallback, useEffect, useMemo, useState } from 'preact/hooks';
 import browser, { type Commands } from 'webextension-polyfill';
 
-import { isChromium, isEdge, isMac } from '../utils/ua-utils';
+import { isChromium, isEdge, isMac, isSafari } from '../utils/ua-utils';
 
 import { KeyboardSettingsForm } from './KeyboardSettingsForm';
 import { Command, CommandError } from './commands';
@@ -174,6 +174,8 @@ async function getToggleKey(): Promise<Command | undefined> {
   // key since Safari also has no way of changing shortcut keys. Hopefully
   // Safari will fix chrome.commands.getAll() before or at the same time it
   // provides a way of re-assigning shortcut keys.
+  //
+  // (See notes below for more recent versions of Safari.)
   if (
     typeof commands === 'object' &&
     typeof commands[Symbol.iterator] !== 'function'
@@ -198,6 +200,14 @@ async function getToggleKey(): Promise<Command | undefined> {
         void Bugsnag.notify(error);
       }
     }
+  }
+
+  // In Safari 17.1, getAll returns an array of opaque WBSWebExtensionCommand
+  // objects.
+  //
+  // Again, just return the hard-coded default key in this case.
+  if (isSafari()) {
+    return new Command('R', 'MacCtrl', 'Ctrl');
   }
 
   return undefined;

--- a/src/options/ToggleKeyForm.tsx
+++ b/src/options/ToggleKeyForm.tsx
@@ -143,7 +143,7 @@ export function ToggleKeyForm(props: Props) {
               onClick={onToggleKeyChange}
               ref={macCtrlKeyRef}
             >
-              <KeyBox label="Control" isMac={props.isMac} />
+              <KeyBox label="Ctrl" isMac={props.isMac} />
               <span class="ml-2">+</span>
             </KeyCheckbox>
           )}
@@ -153,7 +153,37 @@ export function ToggleKeyForm(props: Props) {
             onClick={onToggleKeyChange}
             ref={ctrlKeyRef}
           >
-            <KeyBox label="Ctrl" isMac={props.isMac} />
+            <KeyBox
+              // A few notes about modifier keys on Mac
+              //
+              // In DOM, `ctrlKey` corresponds to "Control" on Mac (and "Ctrl"
+              // on PC).
+              // `metaKey` represents the "Command" (⌘) key.
+              // Ref: https://w3c.github.io/uievents/#dom-keyboardevent-ctrlkey
+              //
+              // In Web extension command shortcuts, "Ctrl" is mapped to
+              // "Command".
+              // `macCtrl` is used for "Control".
+              // Ref: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands#key_combinations
+              //
+              // This deviation probably makes sense in the context of
+              // specifying a cross-platform keyboard shortcut because if your
+              // shortcut is Ctrl+R on Windows it would most naturally be ⌘+R
+              // on Mac.
+              //
+              // Now, for the shortcut keys _we_ handle (i.e. the popup shortcut
+              // keys) we use DOM conventions. That is, we pass "Ctrl" to the
+              // content script and have it check if `ctrlKey` is true.
+              //
+              // As a result, when we describe these keys to the user, they
+              // should show "Control", and that's what KeyBox does when it sees
+              // a label of "Ctrl".
+              //
+              // However, for the special case of the toggle key, the "Ctrl" we
+              // get from the manifest/browser etc. should be shown as "Command".
+              label={props.isMac ? 'Command' : 'Ctrl'}
+              isMac={props.isMac}
+            />
             <span class="ml-2">+</span>
           </KeyCheckbox>
           <KeyCheckbox
@@ -238,8 +268,8 @@ export function ToggleKeyForm(props: Props) {
               props.disabled === 'chrome'
                 ? 'options_browser_commands_no_toggle_key_chrome'
                 : props.disabled === 'edge'
-                ? 'options_browser_commands_no_toggle_key_edge'
-                : 'options_browser_commands_no_toggle_key'
+                  ? 'options_browser_commands_no_toggle_key_edge'
+                  : 'options_browser_commands_no_toggle_key'
             )}
             links={[
               {

--- a/src/options/ToggleKeyForm.tsx
+++ b/src/options/ToggleKeyForm.tsx
@@ -125,7 +125,52 @@ export function ToggleKeyForm(props: Props) {
 
   return (
     <>
-      <div class="flex items-center gap-x-6 gap-y-1">
+      <div class="flex flex-row-reverse flex-wrap items-center justify-end gap-x-6 gap-y-2">
+        <div class="flex grow flex-wrap gap-x-6">
+          <div class="w-min grow">
+            {t('command_toggle_description')}
+            {!!toggleKeyError?.length && (
+              <div
+                class="bg-warning-red ml-2 inline-block h-6 w-6 bg-cover bg-no-repeat align-top"
+                id="toggle-key-icon"
+                title={toggleKeyError}
+              />
+            )}
+          </div>
+          <div>
+            <button
+              class="cursor-pointer appearance-none rounded-md border-none bg-transparent p-0.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+              disabled={!!props.disabled}
+              title={
+                isEmpty
+                  ? t('options_restore_toggle_shortcut')
+                  : t('options_disable_toggle_shortcut')
+              }
+              type="button"
+              onClick={() => {
+                props.onChangeToggleKey(isEmpty ? ResetShortcut : undefined);
+                setToggleKeyError(undefined);
+              }}
+            >
+              {isEmpty ? (
+                <svg class="block h-5 w-5 fill-current" viewBox="0 0 16 16">
+                  <path d="M8.54,2.11l.66-.65A.78.78,0,0,0,9.2.38a.76.76,0,0,0-1.08,0L6.19,2.31A.81.81,0,0,0,6,2.55a.8.8,0,0,0-.06.3A.72.72,0,0,0,6,3.14a.74.74,0,0,0,.17.25L8.12,5.32a.73.73,0,0,0,.54.22.76.76,0,0,0,.54-.22.78.78,0,0,0,0-1.08l-.58-.58A4.38,4.38,0,1,1,3.68,8.82a.76.76,0,0,0-1.5.28,5.92,5.92,0,1,0,6.36-7Z" />
+                  <circle cx={2.673} cy={6.71} r={0.965} />
+                </svg>
+              ) : (
+                <svg class="block h-5 w-5" viewBox="0 0 24 24">
+                  <path
+                    d="M6 18L18 6M6 6l12 12"
+                    stroke="currentColor"
+                    strokeWidth={3}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              )}
+            </button>
+          </div>
+        </div>
         <div class="flex flex-wrap gap-2">
           <KeyCheckbox
             checked={formState.alt}
@@ -213,49 +258,6 @@ export function ToggleKeyForm(props: Props) {
             type="text"
             value={formState.key || ''}
           />
-        </div>
-        <div>
-          {t('command_toggle_description')}
-          {!!toggleKeyError?.length && (
-            <div
-              class="bg-warning-red ml-2 inline-block h-6 w-6 bg-cover bg-no-repeat align-top"
-              id="toggle-key-icon"
-              title={toggleKeyError}
-            />
-          )}
-        </div>
-        <div>
-          <button
-            class="cursor-pointer appearance-none rounded-md border-none bg-transparent p-0.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
-            disabled={!!props.disabled}
-            title={
-              isEmpty
-                ? t('options_restore_toggle_shortcut')
-                : t('options_disable_toggle_shortcut')
-            }
-            type="button"
-            onClick={() => {
-              props.onChangeToggleKey(isEmpty ? ResetShortcut : undefined);
-              setToggleKeyError(undefined);
-            }}
-          >
-            {isEmpty ? (
-              <svg class="block h-5 w-5 fill-current" viewBox="0 0 16 16">
-                <path d="M8.54,2.11l.66-.65A.78.78,0,0,0,9.2.38a.76.76,0,0,0-1.08,0L6.19,2.31A.81.81,0,0,0,6,2.55a.8.8,0,0,0-.06.3A.72.72,0,0,0,6,3.14a.74.74,0,0,0,.17.25L8.12,5.32a.73.73,0,0,0,.54.22.76.76,0,0,0,.54-.22.78.78,0,0,0,0-1.08l-.58-.58A4.38,4.38,0,1,1,3.68,8.82a.76.76,0,0,0-1.5.28,5.92,5.92,0,1,0,6.36-7Z" />
-                <circle cx={2.673} cy={6.71} r={0.965} />
-              </svg>
-            ) : (
-              <svg class="block h-5 w-5" viewBox="0 0 24 24">
-                <path
-                  d="M6 18L18 6M6 6l12 12"
-                  stroke="currentColor"
-                  strokeWidth={3}
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
-            )}
-          </button>
         </div>
       </div>
       {!!props.disabled && (

--- a/src/options/ToggleKeyForm.tsx
+++ b/src/options/ToggleKeyForm.tsx
@@ -137,39 +137,41 @@ export function ToggleKeyForm(props: Props) {
               />
             )}
           </div>
-          <div>
-            <button
-              class="cursor-pointer appearance-none rounded-md border-none bg-transparent p-0.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
-              disabled={!!props.disabled}
-              title={
-                isEmpty
-                  ? t('options_restore_toggle_shortcut')
-                  : t('options_disable_toggle_shortcut')
-              }
-              type="button"
-              onClick={() => {
-                props.onChangeToggleKey(isEmpty ? ResetShortcut : undefined);
-                setToggleKeyError(undefined);
-              }}
-            >
-              {isEmpty ? (
-                <svg class="block h-5 w-5 fill-current" viewBox="0 0 16 16">
-                  <path d="M8.54,2.11l.66-.65A.78.78,0,0,0,9.2.38a.76.76,0,0,0-1.08,0L6.19,2.31A.81.81,0,0,0,6,2.55a.8.8,0,0,0-.06.3A.72.72,0,0,0,6,3.14a.74.74,0,0,0,.17.25L8.12,5.32a.73.73,0,0,0,.54.22.76.76,0,0,0,.54-.22.78.78,0,0,0,0-1.08l-.58-.58A4.38,4.38,0,1,1,3.68,8.82a.76.76,0,0,0-1.5.28,5.92,5.92,0,1,0,6.36-7Z" />
-                  <circle cx={2.673} cy={6.71} r={0.965} />
-                </svg>
-              ) : (
-                <svg class="block h-5 w-5" viewBox="0 0 24 24">
-                  <path
-                    d="M6 18L18 6M6 6l12 12"
-                    stroke="currentColor"
-                    strokeWidth={3}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              )}
-            </button>
-          </div>
+          {!props.disabled && (
+            <div>
+              <button
+                class="cursor-pointer appearance-none rounded-md border-none bg-transparent p-0.5 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+                disabled={!!props.disabled}
+                title={
+                  isEmpty
+                    ? t('options_restore_toggle_shortcut')
+                    : t('options_disable_toggle_shortcut')
+                }
+                type="button"
+                onClick={() => {
+                  props.onChangeToggleKey(isEmpty ? ResetShortcut : undefined);
+                  setToggleKeyError(undefined);
+                }}
+              >
+                {isEmpty ? (
+                  <svg class="block h-5 w-5 fill-current" viewBox="0 0 16 16">
+                    <path d="M8.54,2.11l.66-.65A.78.78,0,0,0,9.2.38a.76.76,0,0,0-1.08,0L6.19,2.31A.81.81,0,0,0,6,2.55a.8.8,0,0,0-.06.3A.72.72,0,0,0,6,3.14a.74.74,0,0,0,.17.25L8.12,5.32a.73.73,0,0,0,.54.22.76.76,0,0,0,.54-.22.78.78,0,0,0,0-1.08l-.58-.58A4.38,4.38,0,1,1,3.68,8.82a.76.76,0,0,0-1.5.28,5.92,5.92,0,1,0,6.36-7Z" />
+                    <circle cx={2.673} cy={6.71} r={0.965} />
+                  </svg>
+                ) : (
+                  <svg class="block h-5 w-5" viewBox="0 0 24 24">
+                    <path
+                      d="M6 18L18 6M6 6l12 12"
+                      stroke="currentColor"
+                      strokeWidth={3}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+              </button>
+            </div>
+          )}
         </div>
         <div class="flex flex-wrap gap-2">
           <KeyCheckbox


### PR DESCRIPTION
- fix: fix shortcut labels on Mac
- fix: make toggle key shortcut key wrap better
- fix: hide button to reset shortcut key when there's no API for it
- fix: show default shortcut key in more recent versions of Safari
