### PR TITLE
Various fixes to 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ app.
 - Made options page more robust with regards to reconnecting to the background
   page (mostly only affects Safari).
 - (Safari) Handle `contextMenus` not being defined on iOS.
+- (Thunderbird) Made workaround for
+  [Gecko bug 1860486](https://bugzilla.mozilla.org/show_bug.cgi?id=1860486)
+  apply to Thunderbird too.
 
 ## [1.16.1] - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ app.
 
 - (Chrome, Edge) Fixed online handling in currency fetching when running as a
   service worker.
+- Made options page more robust with regards to reconnecting to the background
+  page (mostly only affects Safari).
 
 ## [1.16.1] - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ app.
   service worker.
 - Made options page more robust with regards to reconnecting to the background
   page (mostly only affects Safari).
+- (Safari) Handle `contextMenus` not being defined on iOS.
 
 ## [1.16.1] - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- (Chrome, Edge) Fixed online handling in currency fetching when running as a
+  service worker.
+
 ## [1.16.1] - 2023-11-27
 
 - (Chrome, Edge) Removed `"scripting"` from list of permissions.

--- a/src/background/fx-fetcher.ts
+++ b/src/background/fx-fetcher.ts
@@ -8,6 +8,8 @@ import { getReleaseStage } from '../utils/release-stage';
 import { getLocalFxData } from './fx-data';
 import { isError } from '../utils/is-error';
 
+declare let self: (Window | ServiceWorkerGlobalScope) & typeof globalThis;
+
 const FxDataSchema = s.type({
   timestamp: s.min(s.integer(), 0),
   rates: s.record(s.string(), s.number()),
@@ -86,9 +88,9 @@ export class FxFetcher {
 
   private async fetchData() {
     // Don't try fetching if we are offline
-    if (!navigator.onLine) {
+    if (!self.navigator.onLine) {
       Bugsnag.leaveBreadcrumb('Deferring FX data update until we are online');
-      window.addEventListener('online', () => {
+      self.addEventListener('online', () => {
         Bugsnag.leaveBreadcrumb(
           'Fetching FX data update now that we are online'
         );
@@ -105,7 +107,7 @@ export class FxFetcher {
 
     // Abort any timeout to retry
     if (this.fetchState.type === 'waiting to retry') {
-      window.clearTimeout(this.fetchState.timeout);
+      self.clearTimeout(this.fetchState.timeout);
     }
 
     // Update our state

--- a/src/background/jpdict-backend.ts
+++ b/src/background/jpdict-backend.ts
@@ -163,8 +163,8 @@ export class JpdictLocalBackend implements JpdictBackend {
       this.currentUpdate = undefined;
     }
 
-    // Firefox 112+ has an unfortunate bug where, when we try to clear an
-    // objectStore, it just hangs:
+    // Firefox 112+ (and presumably Thunderbird 112+) has an unfortunate bug
+    // where, when we try to clear an objectStore, it just hangs:
     //
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1860486
     //
@@ -175,7 +175,7 @@ export class JpdictLocalBackend implements JpdictBackend {
     // That's quite unfortunate because it means we'll need to download all the
     // names data again which is massive but it's better than having the user be
     // stuck.
-    if (isFirefoxWithBuggyObjectStoreClear()) {
+    if (hasBuggyObjectStoreClear()) {
       // Check if we need to replace the data, i.e. if running an update is
       // likely to try and clear a data series' object store.
       //
@@ -383,11 +383,11 @@ function getLatestCheckTime(db: JpdictIdb): Date | null {
   return latestCheckAsNumber !== 0 ? new Date(latestCheckAsNumber) : null;
 }
 
-function isFirefoxWithBuggyObjectStoreClear() {
+function hasBuggyObjectStoreClear() {
   const userAgent = navigator.userAgent;
-  const firefoxMatch = /Firefox\/(\d+)/.exec(userAgent);
-  if (firefoxMatch && firefoxMatch[1]) {
-    return parseInt(firefoxMatch[1], 10) >= 112;
+  const firefoxOrThunderbird = /(?:Firefox|Thunderbird)\/(\d+)/.exec(userAgent);
+  if (firefoxOrThunderbird && firefoxOrThunderbird[1]) {
+    return parseInt(firefoxOrThunderbird[1], 10) >= 112;
   }
   return false;
 }


### PR DESCRIPTION
- fix: make currency fetching work in a service worker context
- fix: more robust handling of connection between options page and background page
- fix: handle contextMenus not being defined
- fix: apply objectStore.clear() workaround to Thunderbird too
