### PR TITLE
fix: fix tab manager initialization race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ app.
 - Added option to show Bunpro vocabulary and grammar labels next to words
   ([#1383](https://github.com/birchill/10ten-ja-reader/issues/1383)).
 - Added localizations for newly-introduced field tags.
+- Fixed a bug where it would take two clicks to enable the add-on sometimes
+  ([#1491](https://github.com/birchill/10ten-ja-reader/issues/1491)).
 - Fixed slow lookup for long text spans
   ([#1423](https://github.com/birchill/10ten-ja-reader/issues/1423)).
 - Fixed options page becoming disconnected from the background page (again).


### PR DESCRIPTION
STR:

1. Start the add-on but don't enable it
2. Wait for the download to finish
3. Terminate the background process from about:debugging (or just wait
   for it to terminate)
4. On any regular Web page, enable the add-on by clicking the icon on the
   toolbar

Expected results:

The add-on is enabled immediately.

Actual results:

It takes two clicks.

Analysis:

We'd hit a race condition where we'd call tabManager.init() while the
tabManager was still being initialized. As a result it would update its
this.enabled member to `true` but then the initialization steps would
reset it back to false.

The fix is just to wait for the initialization to complete before trying
to toggle the value.

As far as I can tell this does not affect the ActiveTabManager because
its initialization is synchronous.

Fixes #1491.
