### PR TITLE
feat: improve rendering of source language information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ app.
 ## [Unreleased]
 
 - Added localization and handling for new `rk` (rarely-used kana form) tag.
+- Improved rendering of source language information
+  ([#1468](https://github.com/birchill/10ten-ja-reader/issues/1468)).
 
 ## [1.17.0] - 2023-12-06
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1111,7 +1111,7 @@
     "description": "Label used to describe senses whose source language is 'lt' (Lithuanian)"
   },
   "lang_label_mi": {
-    "message": "Maori",
+    "message": "Māori",
     "description": "Label used to describe senses whose source language is 'mi' (Maori)"
   },
   "lang_label_ml": {
@@ -1218,10 +1218,6 @@
     "message": "Vietnamese",
     "description": "Label used to describe senses whose source language is 'vi' (Vietnamese)"
   },
-  "lang_label_wasei": {
-    "message": "wasei",
-    "description": "Label used to describe senses that are Japanese constructions (of English, presumably, as opposed to wasei kango)"
-  },
   "lang_label_yi": {
     "message": "Yiddish",
     "description": "Label used to describe senses whose source language is 'yi' (Yiddish)"
@@ -1229,6 +1225,27 @@
   "lang_label_zh": {
     "message": "Chinese",
     "description": "Label used to describe senses whose source language is 'zh' (Chinese)"
+  },
+  "lang_lsrc_prefix": {
+    "message": " (from ",
+    "description": "The start of the text used to indicate a source language, e.g. ' (from English)'"
+  },
+  "lang_lsrc_suffix": {
+    "message": ")",
+    "description": "The end of the text used to indicate a source language"
+  },
+  "lang_lsrc_wasei": {
+    "message": "wasei $lang$",
+    "placeholders": {
+      "lang": {
+        "content": "$1",
+        "example": "English"
+      }
+    }
+  },
+  "lang_lsrc_wasei_prefix": {
+    "message": " (",
+    "description": "The start of the text used to indicate a source language when the first source language is waseigo, e.g. ' (wasei English)'"
   },
   "lang_tag": {
     "message": "en",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1218,10 +1218,6 @@
     "message": "ベトナム語",
     "description": "Label used to describe senses whose source language is 'vi' (Vietnamese)"
   },
-  "lang_label_wasei": {
-    "message": "和製",
-    "description": "Label used to describe senses that are Japanese constructions (of English, presumably, as opposed to wasei kango)"
-  },
   "lang_label_yi": {
     "message": "イディッシュ語",
     "description": "Label used to describe senses whose source language is 'yi' (Yiddish)"
@@ -1229,6 +1225,27 @@
   "lang_label_zh": {
     "message": "中国語",
     "description": "Label used to describe senses whose source language is 'zh' (Chinese)"
+  },
+  "lang_lsrc_prefix": {
+    "message": "（",
+    "description": "The start of the text used to indicate a source language, e.g. ' (from English)'"
+  },
+  "lang_lsrc_suffix": {
+    "message": "）",
+    "description": "The end of the text used to indicate a source language"
+  },
+  "lang_lsrc_wasei": {
+    "message": "和製​$lang$",
+    "placeholders": {
+      "lang": {
+        "content": "$1",
+        "example": "英語"
+      }
+    }
+  },
+  "lang_lsrc_wasei_prefix": {
+    "message": "（",
+    "description": "The start of the text used to indicate a source language when the first source language is waseigo, e.g. ' (wasei English)'"
   },
   "lang_tag": {
     "message": "ja",

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -1218,10 +1218,6 @@
     "message": "越南语",
     "description": "Label used to describe senses whose source language is 'vi' (Vietnamese)"
   },
-  "lang_label_wasei": {
-    "message": "和制英语",
-    "description": "Label used to describe senses that are Japanese constructions (of English, presumably, as opposed to wasei kango)"
-  },
   "lang_label_yi": {
     "message": "意第绪语",
     "description": "Label used to describe senses whose source language is 'yi' (Yiddish)"
@@ -1229,6 +1225,27 @@
   "lang_label_zh": {
     "message": "汉语",
     "description": "Label used to describe senses whose source language is 'zh' (Chinese)"
+  },
+  "lang_lsrc_prefix": {
+    "message": "（",
+    "description": "The start of the text used to indicate a source language, e.g. ' (from English)'"
+  },
+  "lang_lsrc_suffix": {
+    "message": "）",
+    "description": "The end of the text used to indicate a source language"
+  },
+  "lang_lsrc_wasei": {
+    "message": "和制​$lang$",
+    "placeholders": {
+      "lang": {
+        "content": "$1",
+        "example": "英语"
+      }
+    }
+  },
+  "lang_lsrc_wasei_prefix": {
+    "message": "（",
+    "description": "The start of the text used to indicate a source language when the first source language is waseigo, e.g. ' (wasei English)'"
   },
   "lang_tag": {
     "message": "zh-Hans",

--- a/src/content/popup/words.ts
+++ b/src/content/popup/words.ts
@@ -744,7 +744,7 @@ function renderSense(
     );
   }
 
-  if (sense.lsrc && sense.lsrc.length) {
+  if (sense.lsrc?.length) {
     fragment.append(renderLangSources(sense.lsrc));
   }
 
@@ -773,41 +773,39 @@ function appendGlosses(glosses: Array<Gloss>, parent: ParentNode) {
   }
 }
 
-function renderLangSources(sources: Array<LangSource>): DocumentFragment {
-  const container = document.createDocumentFragment();
+function renderLangSources(sources: Array<LangSource>): HTMLElement {
+  const sourceLangSpan = html('span', { class: 'w-lsrc', lang: getLangTag() });
 
-  for (const lsrc of sources) {
-    container.append(' ');
+  const startsWithWasei = sources[0]?.wasei;
+  sourceLangSpan.append(
+    browser.i18n.getMessage(
+      startsWithWasei ? 'lang_lsrc_wasei_prefix' : 'lang_lsrc_prefix'
+    )
+  );
 
-    let prefix = lsrc.wasei
-      ? browser.i18n.getMessage('lang_label_wasei')
-      : undefined;
-    if (!prefix) {
-      prefix =
-        browser.i18n.getMessage(`lang_label_${lsrc.lang || 'en'}`) || lsrc.lang;
+  for (const [i, lsrc] of sources.entries()) {
+    if (i) {
+      sourceLangSpan.append(', ');
     }
 
-    const wrapperSpan = html(
-      'span',
-      { class: 'w-lsrc', lang: getLangTag() },
-      '('
-    );
+    const lang =
+      browser.i18n.getMessage(`lang_label_${lsrc.lang || 'en'}`) ||
+      lsrc.lang ||
+      'English';
+    const prefix = lsrc.wasei
+      ? browser.i18n.getMessage('lang_lsrc_wasei', [lang])
+      : lang;
 
-    if (prefix && lsrc.src) {
-      prefix = `${prefix}: `;
-    }
-    if (prefix) {
-      wrapperSpan.append(prefix);
-    }
+    sourceLangSpan.append(lsrc.src ? `${prefix}: ` : prefix);
 
     if (lsrc.src) {
-      wrapperSpan.append(html('span', { lang: lsrc.lang }, lsrc.src));
+      sourceLangSpan.append(
+        html('span', { lang: lsrc.lang || 'en' }, lsrc.src)
+      );
     }
-
-    wrapperSpan.append(')');
-
-    container.append(wrapperSpan);
   }
 
-  return container;
+  sourceLangSpan.append(browser.i18n.getMessage('lang_lsrc_suffix'));
+
+  return sourceLangSpan;
 }


### PR DESCRIPTION
In English we prefix the annotation with "from", e.g. "(from English)"
or "(from English: computer allergy)".

However, for wasei eigo we drop the "from", e.g. "(wasei English)".

We also indicate the source language for waseigo, e.g. "(wasei German:
Sack)".

We render wasei eigo as "wasei English" in the English localization
since some users will have an easier time parsing that than the more
common "wasei eigo" and anyone who understands "wasei eigo" will be able
to understand  "wasei English" too.

Some test cases I used for this:

- コンピューターアレルギー
- コンブリオ
- ナウ
- ゴータビリティー
- コンピュータマニア
- コンビナートキャンペーン
- サブザック
- シラー

Fixes #1468.
