### PR TITLE
fix: workaround MV3 CSP limitations in Google Docs bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ app.
 
 ## [Unreleased]
 
+- Fixed support for Google Docs on chromium browsers (Chrome, Edge, Opera, etc.)
+  ([#1529](https://github.com/birchill/10ten-ja-reader/issues/1529)).
 - Added localization and handling for new `rk` (rarely-used kana form) tag.
 - Improved rendering of source language information
   ([#1468](https://github.com/birchill/10ten-ja-reader/issues/1468)).

--- a/manifest.json.src
+++ b/manifest.json.src
@@ -153,7 +153,8 @@
       "matches": ["https://docs.google.com/*"],
       "js": ["10ten-ja-gdocs-bootstrap.js"],
       "all_frames": true,
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "world": "MAIN"
     }
   ],
   /*#endif*/

--- a/src/content/gdocs-bootstrap.ts
+++ b/src/content/gdocs-bootstrap.ts
@@ -1,5 +1,11 @@
-const scriptElem = document.createElement('script');
-scriptElem.textContent =
-  "(function() { window['_docs_annotate_canvas_by_ext'] = 'pnmaklegiibbioifkmfkgpfnmdehdfan'; })();";
-(document.head || document.documentElement).appendChild(scriptElem);
-scriptElem.remove();
+// If we're on Firefox but we're not running in the main world (because Firefox
+// doesn't support that yet due to
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1736575)
+// then we can still access the main world's window object by unwrapping it.
+if ((window as any).wrappedJSObject) {
+  (window as any).wrappedJSObject._docs_annotate_canvas_by_ext =
+    'pnmaklegiibbioifkmfkgpfnmdehdfan';
+} else {
+  (window as any)._docs_annotate_canvas_by_ext =
+    'pnmaklegiibbioifkmfkgpfnmdehdfan';
+}


### PR DESCRIPTION
Fixes #1529.

MV3 only allows the values "self", "wasm-unsafe-eval", and
"wasm-unsafe-eval" for an extension's `script-src` CSP setting.

As a result, we can no longer use inline script to update the main world
`window` global in order to enable Google Docs' annotated canvas mode.

Instead we use the new `world: 'MAIN'` setting and in Firefox, which
doesn't yet support that setting, we use Firefox's X-ray vision object
unwrapping.

Safari doesn't support Google Docs' annotated canvas due to:

  https://bugs.webkit.org/show_bug.cgi?id=232781

However, Safari have indicated support for implementing `world: 'MAIN'`
in:

  https://github.com/w3c/webextensions/issues/485
