### PR TITLE
chore: stop reporting common storage errors

### DIFF
--- a/src/background/fx-data.ts
+++ b/src/background/fx-data.ts
@@ -2,8 +2,6 @@ import Bugsnag from '@birchill/bugsnag-zero';
 import * as s from 'superstruct';
 import browser from 'webextension-polyfill';
 
-import { ExtensionStorageError } from '../common/extension-storage-error';
-
 const FxLocalDataSchema = s.type({
   timestamp: s.min(s.integer(), 0),
   rates: s.record(s.string(), s.number()),
@@ -28,14 +26,11 @@ export async function getLocalFxData(
 
     if (validated) {
       return validated;
-    } else if (error) {
+    } else {
       void Bugsnag.notify(error, { severity: 'warning' });
     }
-  } catch (e) {
-    void Bugsnag.notify(
-      new ExtensionStorageError({ key: 'fx', action: 'get' }),
-      { severity: 'warning', metadata: { error: e } }
-    );
+  } catch {
+    console.warn('Failed to get fx data from storage');
   }
 
   return undefined;

--- a/src/background/jpdict.ts
+++ b/src/background/jpdict.ts
@@ -263,10 +263,7 @@ async function getLastUpdateTime(): Promise<number | null> {
   } catch {
     // Extension storage can sometimes randomly fail with 'An unexpected error
     // occurred'. Ignore, but log it.
-    void Bugsnag.notify(
-      new ExtensionStorageError({ key: 'lastDbUpdateTime', action: 'get' }),
-      { severity: 'warning' }
-    );
+    console.warn('Failed to get last update time from storage');
   }
 
   return null;


### PR DESCRIPTION
These happen a lot in Firefox and there doesn't seem to be anything we
can do about them short of retrying.

For now, notifying is just creating noise so we should log to the
console instead.
