### PR TITLE
fix: stop popup being inverted in Wikipedia's experimental dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ app.
 
 ## [Unreleased]
 
+- Stopped popup being inverted when Wikipedia's experimental dark mode is
+  enabled
+  ([#1590](https://github.com/birchill/10ten-ja-reader/issues/1590)).
+
 ## [1.17.1] - 2024-01-04
 
 - (Chrome, Edge) Fixed support for Google Docs on chromium browsers

--- a/src/content/popup/popup.ts
+++ b/src/content/popup/popup.ts
@@ -295,7 +295,7 @@ export function renderPopup(
 }
 
 function getDefaultContainer(): HTMLElement {
-  return getOrCreateEmptyContainer({
+  const defaultContainer = getOrCreateEmptyContainer({
     id: 'tenten-ja-window',
     styles: popupStyles.toString(),
     // Make sure the popup container appears _before_ the puck container so that
@@ -303,6 +303,15 @@ function getDefaultContainer(): HTMLElement {
     before: LookupPuck.id,
     legacyIds: ['rikaichamp-window'],
   });
+
+  // Make sure our popup doesn't get inverted by Wikipedia's (experimental) dark
+  // mode.
+  if (document.location.hostname.endsWith('wikipedia.org')) {
+    defaultContainer.classList.add('mw-no-invert');
+    defaultContainer.style.filter = 'inherit';
+  }
+
+  return defaultContainer;
 }
 
 function resetContainer({


### PR DESCRIPTION
Fixes #1590.
