### PR TITLE
fix: copy rare headwords when not in simplified copy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ app.
 
 ## [Unreleased]
 
+- Made copying to the clipboard include rare headwords again when not using
+  simplified copy mode
+  ([#1665](https://github.com/birchill/10ten-ja-reader/issues/1665)).
+
 ## [1.18.0] - 2024-02-26
 
 - Made the puck persist its position, orientation, and active state between

--- a/src/content/copy-text.ts
+++ b/src/content/copy-text.ts
@@ -238,15 +238,7 @@ function filterRelevantKanjiHeadwords(
   }
 ) {
   if (includeLessCommonHeadwords) {
-    // Exclude search-only / rare headwords unless we matched on them.
-    //
-    // The reason we include search-only / rare headwords if we matched on them
-    // is that it's quite possible that if a user matched on a rare headword
-    // such as a rare kanji they'd like to copy it to the clipboard for further
-    // searching.
-    return headwords.filter(
-      (k) => (!k.i?.includes('sK') && !k.i?.includes('rK')) || k.matchRange
-    );
+    return headwords.filter((k) => !k.i?.includes('sK'));
   }
 
   const commonHeadwords = headwords.filter(
@@ -279,9 +271,7 @@ function filterRelevantKanaHeadwords(
   }
 ) {
   if (includeLessCommonHeadwords) {
-    return headwords.filter(
-      (k) => (!k.i?.includes('sk') && !k.i?.includes('rk')) || k.matchRange
-    );
+    return headwords.filter((k) => !k.i?.includes('sk'));
   }
 
   const commonHeadwords = headwords.filter(


### PR DESCRIPTION
Fixes #1665.
