### PR TITLE
feat: add more helpful message when data storage is unavailable on Firefox

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1621,6 +1621,10 @@
     "message": "Database storage unavailable",
     "description": "Label when IndexedDB is unusable"
   },
+  "options_database_unavailable_firefox": {
+    "message": "Database storage unavailable. This may be due to Firefox being set to “Never remember history”.",
+    "description": "Label when IndexedDB is unusable with Firefox-specific help."
+  },
   "options_db_update_error": {
     "message": "Update failed: $errormessage$",
     "description": "Label when we failed to update the data for some reason",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1621,6 +1621,10 @@
     "message": "データベースストレージ利用不可",
     "description": "Label when IndexedDB is unusable"
   },
+  "options_database_unavailable_firefox": {
+    "message": "データベースストレージ利用不可。Firefoxが「履歴を一切記憶させない」に設定されているかどうかご確認ください。",
+    "description": "Label when IndexedDB is unusable with Firefox-specific help."
+  },
   "options_db_update_error": {
     "message": "更新失敗しました。「​$errormessage$​」",
     "description": "Label when we failed to update the data for some reason",

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -1621,6 +1621,10 @@
     "message": "数据库存储不可用",
     "description": "Label when IndexedDB is unusable"
   },
+  "options_database_unavailable_firefox": {
+    "message": "数据库存储不可用。请检查Firefox是否设置为‘不记录历史’。",
+    "description": "Label when IndexedDB is unusable with Firefox-specific help."
+  },
   "options_db_update_error": {
     "message": "更新失败：​$errormessage$",
     "description": "Label when we failed to update the data for some reason",

--- a/src/options/DbStatus.tsx
+++ b/src/options/DbStatus.tsx
@@ -274,7 +274,12 @@ function useErrorDetails(dbState: JpdictState): {
   // Otherwise, return a suitable summary error
   const summaryStates: Array<[DataSeriesState, string]> = [
     ['init', 'options_database_initializing'],
-    ['unavailable', 'options_database_unavailable'],
+    [
+      'unavailable',
+      isFirefox()
+        ? 'options_database_unavailable_firefox'
+        : 'options_database_unavailable',
+    ],
     ['empty', 'options_no_database'],
   ];
   for (const [state, key] of summaryStates) {


### PR DESCRIPTION
Fixes #1507.
