### PR TITLE
bugfix: fix broken touch scrolling

### DIFF
--- a/src/content/popup/swipe.ts
+++ b/src/content/popup/swipe.ts
@@ -27,15 +27,6 @@ export function onHorizontalSwipe(
   );
 
   element.addEventListener(
-    'touchmove',
-    function (e) {
-      // Prevent dragging viewport
-      e.preventDefault();
-    },
-    false
-  );
-
-  element.addEventListener(
     'touchend',
     function (e) {
       const touch = e.changedTouches[0];


### PR DESCRIPTION
I noticed scrolling on a touchscreen was not working on the newest `main`, then after a little investigation discovered this was (embarrassingly) introduced by my own tab swiping patch, and an overzealous `preventDefault()` call. Honestly, I'm not even sure why I had that in there to begin with...

Sure glad this hasn't been shipped yet! Sorry about that.