### PR TITLE
fix: show kanji encoded as radicals in kanji tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- Fixed kanji incorrectly encoded as radicals not being displayed in kanji tab
+  ([#1205](https://github.com/birchill/10ten-ja-reader/issues/1205#issuecomment-1783641017)).
+
 ## [1.19.0] - 2024-05-30
 
 - Made it possible to change tabs in the popup by swiping horizontally

--- a/src/background/jpdict.ts
+++ b/src/background/jpdict.ts
@@ -445,6 +445,9 @@ export async function searchKanji(
     return 'updating';
   }
 
+  // Normalize the input in order to be able to parse radicals as kanji.
+  const [normalized] = normalizeInput(input);
+
   // Do some very elementary filtering on kanji
   //
   // We know that the input should be mostly Japanese so we just do some very
@@ -457,7 +460,7 @@ export async function searchKanji(
   const kanjiLastIndex = new Map<string, number>();
   const kanji = [
     ...new Set(
-      [...input].filter((c, i) => {
+      [...normalized].filter((c, i) => {
         const cp = c.codePointAt(0)!;
         const isKanji =
           // Don't bother looking up Latin text


### PR DESCRIPTION
Fixes https://github.com/birchill/10ten-ja-reader/issues/1205#issuecomment-1783641017.

**Side effects:** Combined characters like ㋿ will also be displayed as two separate kanji in the Kanji tab. Therefore there is a more consistent representation between the Word tab and the Kanji tab.