### PR TITLE
fix: fix duplicate matching of names with both 新字体 and 旧字体

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ app.
 ## [Unreleased]
 
 - Added support for irregular verb forms of 給う
+  thanks to [@Enellis](https://github.com/Enellis)
   ([#1470](https://github.com/birchill/10ten-ja-reader/issues/1470)).
 - Fixed recognition of continuous forms of verbs with irregular te form.
+  thanks to [@Enellis](https://github.com/Enellis)
   ([#1811](https://github.com/birchill/10ten-ja-reader/pull/1811)).
+- Fixed duplicate matching of names with both 新字体 and 旧字体
+  ([#1830](https://github.com/birchill/10ten-ja-reader/issues/1830)).
 
 ## [1.19.1] - 2024-06-08
 

--- a/src/background/name-search.ts
+++ b/src/background/name-search.ts
@@ -29,6 +29,10 @@ export async function nameSearch({
   // Record the position of existing entries for grouping purposes
   const existingItems = new Map<string, number>();
 
+  // Record which entries we have already seen so we don't try to merge the same
+  // entries when matching on variants
+  const have = new Set<number>();
+
   let currentString = input;
 
   while (currentString.length > 0) {
@@ -66,6 +70,8 @@ export async function nameSearch({
         return null;
       }
 
+      // Filter out entries we already have
+      names = names.filter((name) => !have.has(name.id));
       if (!names.length) {
         continue;
       }
@@ -73,6 +79,8 @@ export async function nameSearch({
       result.matchLen = Math.max(result.matchLen, currentInputLength);
 
       for (const name of names) {
+        have.add(name.id);
+
         // We group together entries where the kana readings and translation
         // details are all equal.
         const nameContents = getNameEntryHash(name);

--- a/src/background/word-search.ts
+++ b/src/background/word-search.ts
@@ -40,7 +40,7 @@ export async function wordSearch({
   includeRomaji: boolean;
 }): Promise<WordSearchResult | null> {
   let longestMatch = 0;
-  let have: Set<number> = new Set();
+  let have = new Set<number>();
   const result: WordSearchResult = {
     type: 'words',
     data: [],


### PR DESCRIPTION
Fixes #1830.
