### PR TITLE
feat: Add option to use imperial units when doing unit conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ app.
   ([#1811](https://github.com/birchill/10ten-ja-reader/pull/1811)).
 - Fixed duplicate matching of names with both 新字体 and 旧字体
   ([#1830](https://github.com/birchill/10ten-ja-reader/issues/1830)).
+- Added supported for doing unit conversions to imperial units
+  ([#1836](https://github.com/birchill/10ten-ja-reader/pull/1836))
 
 ## [1.19.1] - 2024-06-08
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2028,6 +2028,22 @@
     "message": "Look up text by tapping",
     "description": "Checkbox label for setting to enable looking up by tapping a word"
   },
+  "options_unit_conversion_heading": {
+    "message": "Unit conversion",
+    "description": "Heading for the section for configuring unit conversion"
+  },
+  "options_units_imperial_label": {
+    "message": "imperial",
+    "description": "Label for the 'imperial' drop-down item"
+  },
+  "options_units_label": {
+    "message": "Preferred units",
+    "description": "Label for the drop-down box for choosing the preferred units"
+  },
+  "options_units_metric_label": {
+    "message": "metric",
+    "description": "Label for the 'metric' drop-down item"
+  },
   "options_update_check_button_label": {
     "message": "Check for updates",
     "description": "Label for the button to check for database updates"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2033,7 +2033,7 @@
     "description": "Heading for the section for configuring unit conversion"
   },
   "options_units_imperial_label": {
-    "message": "imperial",
+    "message": "Imperial",
     "description": "Label for the 'imperial' drop-down item"
   },
   "options_units_label": {
@@ -2041,7 +2041,7 @@
     "description": "Label for the drop-down box for choosing the preferred units"
   },
   "options_units_metric_label": {
-    "message": "metric",
+    "message": "Metric",
     "description": "Label for the 'metric' drop-down item"
   },
   "options_update_check_button_label": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -2028,6 +2028,22 @@
     "message": "タップでテキストを調べる",
     "description": "Checkbox label for setting to enable looking up by tapping a word"
   },
+  "options_unit_conversion_heading": {
+    "message": "単位換算",
+    "description": "Heading for the section for configuring unit conversion"
+  },
+  "options_units_imperial_label": {
+    "message": "ヤード・ポンド法",
+    "description": "Label for the 'imperial' drop-down item"
+  },
+  "options_units_label": {
+    "message": "単位系",
+    "description": "Label for the drop-down box for choosing the preferred units"
+  },
+  "options_units_metric_label": {
+    "message": "メートル法",
+    "description": "Label for the 'metric' drop-down item"
+  },
   "options_update_check_button_label": {
     "message": "更新を確認",
     "description": "Label for the button to check for database updates"

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -2028,6 +2028,22 @@
     "message": "点触文本以查询",
     "description": "Checkbox label for setting to enable looking up by tapping a word"
   },
+  "options_unit_conversion_heading": {
+    "message": "单位转换",
+    "description": "Heading for the section for configuring unit conversion"
+  },
+  "options_units_imperial_label": {
+    "message": "英制",
+    "description": "Label for the 'imperial' drop-down item"
+  },
+  "options_units_label": {
+    "message": "单位制",
+    "description": "Label for the drop-down box for choosing the preferred units"
+  },
+  "options_units_metric_label": {
+    "message": "公制",
+    "description": "Label for the 'metric' drop-down item"
+  },
   "options_update_check_button_label": {
     "message": "检查更新",
     "description": "Label for the button to check for database updates"

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -66,7 +66,6 @@ interface Settings {
   fontFace?: FontFace;
   fontSize?: FontSize;
   fxCurrency?: string;
-  preferredUnits?: 'metric' | 'imperial';
   highlightStyle?: HighlightStyle;
   holdToShowKeys?: string;
   holdToShowImageKeys?: string;
@@ -81,6 +80,7 @@ interface Settings {
   noTextHighlight?: boolean;
   popupStyle?: string;
   posDisplay?: PartOfSpeechDisplay;
+  preferredUnits?: 'metric' | 'imperial';
   readingOnly?: boolean;
   showKanjiComponents?: boolean;
   showPriority?: boolean;
@@ -775,21 +775,6 @@ export class Config {
       : undefined;
   }
 
-  get preferredUnits(): 'metric' | 'imperial' {
-    return typeof this.settings.preferredUnits === 'string'
-      ? this.settings.preferredUnits
-      : 'metric';
-  }
-
-  set preferredUnits(value: 'metric' | 'imperial') {
-    if (this.settings.preferredUnits === value) {
-      return;
-    }
-
-    this.settings.preferredUnits = value;
-    void browser.storage.sync.set({ preferredUnits: value });
-  }
-
   // highlightStyle: Defaults to 'yellow'
 
   get highlightStyle(): HighlightStyle {
@@ -1103,6 +1088,21 @@ export class Config {
     void browser.storage.sync.set({ posDisplay: value });
   }
 
+  // preferredUnits: Defaults to 'metric'
+
+  get preferredUnits(): 'metric' | 'imperial' {
+    return this.settings.preferredUnits || 'metric';
+  }
+
+  set preferredUnits(value: 'metric' | 'imperial') {
+    if (this.settings.preferredUnits === value) {
+      return;
+    }
+
+    this.settings.preferredUnits = value;
+    void browser.storage.sync.set({ preferredUnits: value });
+  }
+
   // readingOnly: Defaults to false
 
   get readingOnly(): boolean {
@@ -1325,7 +1325,6 @@ export class Config {
               timestamp: this.fxData.timestamp,
             }
           : undefined,
-      preferredUnits: this.preferredUnits,
       fontFace: this.fontFace,
       fontSize: this.fontSize,
       highlightStyle: this.highlightStyle,
@@ -1341,6 +1340,7 @@ export class Config {
       popupInteractive: this.popupInteractive,
       popupStyle: this.popupStyle,
       posDisplay: this.posDisplay,
+      preferredUnits: this.preferredUnits,
       puckState: this.puckState,
       readingOnly: this.readingOnly,
       showKanjiComponents: this.showKanjiComponents,

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -66,6 +66,7 @@ interface Settings {
   fontFace?: FontFace;
   fontSize?: FontSize;
   fxCurrency?: string;
+  preferredUnits?: 'metric' | 'imperial';
   highlightStyle?: HighlightStyle;
   holdToShowKeys?: string;
   holdToShowImageKeys?: string;
@@ -401,6 +402,9 @@ export class Config {
   // decorators and in any case, won't transpile them:
   //
   //   https://github.com/evanw/esbuild/issues/104
+  //
+  // UPDATE: Looks like support was added for decorators as of esbuild v0.21.3
+  // https://github.com/evanw/esbuild/releases/tag/v0.21.3
   //
   // Our options are either to use SWC (which runs the risk of behaving a bit
   // differently to TypeScript) or try to get TSC to transpile the relevant
@@ -769,6 +773,21 @@ export class Config {
     return this.fxData
       ? Object.keys(this.fxData.rates).sort((a, b) => a.localeCompare(b))
       : undefined;
+  }
+
+  get preferredUnits(): 'metric' | 'imperial' {
+    return typeof this.settings.preferredUnits === 'string'
+      ? this.settings.preferredUnits
+      : 'metric';
+  }
+
+  set preferredUnits(value: 'metric' | 'imperial') {
+    if (this.settings.preferredUnits === value) {
+      return;
+    }
+
+    this.settings.preferredUnits = value;
+    void browser.storage.sync.set({ preferredUnits: value });
   }
 
   // highlightStyle: Defaults to 'yellow'
@@ -1306,6 +1325,7 @@ export class Config {
               timestamp: this.fxData.timestamp,
             }
           : undefined,
+      preferredUnits: this.preferredUnits,
       fontFace: this.fontFace,
       fontSize: this.fontSize,
       highlightStyle: this.highlightStyle,

--- a/src/common/content-config-params.ts
+++ b/src/common/content-config-params.ts
@@ -81,9 +81,6 @@ export interface ContentConfigParams {
   // for the rate.
   fx: { currency: string; rate: number; timestamp: number } | undefined;
 
-  // The user's preferred units
-  preferredUnits: 'metric' | 'imperial';
-
   // The fonts to use in the popup.
   fontFace: FontFace;
 
@@ -121,6 +118,9 @@ export interface ContentConfigParams {
 
   // Indicates the type of display to use for part-of-speech labels.
   posDisplay: PartOfSpeechDisplay;
+
+  // The user's preferred units for unit conversion
+  preferredUnits: 'metric' | 'imperial';
 
   // The state of the puck on the screen (e.g. position, orientation, active
   // state etc.)

--- a/src/common/content-config-params.ts
+++ b/src/common/content-config-params.ts
@@ -81,6 +81,9 @@ export interface ContentConfigParams {
   // for the rate.
   fx: { currency: string; rate: number; timestamp: number } | undefined;
 
+  // The user's preferred units
+  preferredUnits: 'metric' | 'imperial';
+
   // The fonts to use in the popup.
   fontFace: FontFace;
 

--- a/src/content/content-config.ts
+++ b/src/content/content-config.ts
@@ -142,6 +142,9 @@ export class ContentConfig implements ContentConfigParams {
   get fx() {
     return this.params.fx;
   }
+  get preferredUnits() {
+    return this.params.preferredUnits;
+  }
   get fontFace() {
     return this.params.fontFace;
   }

--- a/src/content/content-config.ts
+++ b/src/content/content-config.ts
@@ -142,9 +142,6 @@ export class ContentConfig implements ContentConfigParams {
   get fx() {
     return this.params.fx;
   }
-  get preferredUnits() {
-    return this.params.preferredUnits;
-  }
   get fontFace() {
     return this.params.fontFace;
   }
@@ -179,6 +176,9 @@ export class ContentConfig implements ContentConfigParams {
   }
   get posDisplay() {
     return this.params.posDisplay;
+  }
+  get preferredUnits() {
+    return this.params.preferredUnits;
   }
   get puckState() {
     return this.params.puckState;

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -2223,7 +2223,6 @@ export class ContentHandler {
       fontFace: this.config.fontFace,
       fontSize: this.config.fontSize,
       fxData: this.config.fx,
-      preferredUnits: this.config.preferredUnits,
       getCursorClearanceAndPos: this.getCursorClearanceAndPos.bind(
         this,
         screenTextBoxSizes
@@ -2268,6 +2267,7 @@ export class ContentHandler {
       popupStyle: this.config.popupStyle,
       posDisplay: this.config.posDisplay,
       positionMode: this.popupPositionMode,
+      preferredUnits: this.config.preferredUnits,
       previousHeight: this.popupState?.pos?.height,
       safeArea: this.safeAreaProvider.getSafeArea(),
       showDefinitions: !this.config.readingOnly,

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -2223,6 +2223,7 @@ export class ContentHandler {
       fontFace: this.config.fontFace,
       fontSize: this.config.fontSize,
       fxData: this.config.fx,
+      preferredUnits: this.config.preferredUnits,
       getCursorClearanceAndPos: this.getCursorClearanceAndPos.bind(
         this,
         screenTextBoxSizes

--- a/src/content/popup/metadata.test.ts
+++ b/src/content/popup/metadata.test.ts
@@ -186,6 +186,7 @@ function getShogiMove(
 ): string | undefined {
   const params: Parameters<typeof renderMetadata>[0] = {
     fxData: undefined,
+    preferredUnits: 'metric',
     isCombinedResult: false,
     matchLen: 5, // Not used
     meta: {

--- a/src/content/popup/metadata.ts
+++ b/src/content/popup/metadata.ts
@@ -156,6 +156,8 @@ function renderUnit(
 
   if (unit === 'm2') {
     unitSpan.append('m', html('sup', {}, '2'));
+  } else if (unit === 'sq ft') {
+    unitSpan.append('ft', html('sup', {}, '2'));
   } else if (showRuby) {
     unitSpan.append(
       html(

--- a/src/content/popup/metadata.ts
+++ b/src/content/popup/metadata.ts
@@ -14,11 +14,13 @@ import { getLangTag } from './lang-tag';
 
 export function renderMetadata({
   fxData,
+  preferredUnits,
   isCombinedResult,
   matchLen,
   meta,
 }: {
   fxData: ContentConfigParams['fx'];
+  preferredUnits: ContentConfigParams['preferredUnits'];
   isCombinedResult: boolean;
   matchLen: number;
   meta: SelectionMeta;
@@ -34,7 +36,7 @@ export function renderMetadata({
       break;
 
     case 'measure':
-      return renderMeasureInfo(meta);
+      return renderMeasureInfo(meta, preferredUnits);
 
     case 'currency':
       return fxData ? renderCurrencyInfo(meta, fxData) : null;
@@ -76,8 +78,11 @@ function renderEraInfo(meta: EraMeta, eraInfo: EraInfo): HTMLElement {
   );
 }
 
-function renderMeasureInfo(meta: MeasureMeta): HTMLElement {
-  const converted = convertMeasure(meta);
+function renderMeasureInfo(
+  meta: MeasureMeta,
+  preferredUnits: ContentConfigParams['preferredUnits']
+): HTMLElement {
+  const converted = convertMeasure(meta, preferredUnits);
 
   const metaDiv = html(
     'div',

--- a/src/content/popup/names.ts
+++ b/src/content/popup/names.ts
@@ -27,6 +27,7 @@ export function renderNamesEntries({
   if (options.meta) {
     const metadata = renderMetadata({
       fxData: options.fxData,
+      preferredUnits: options.preferredUnits,
       isCombinedResult: true,
       matchLen,
       meta: options.meta,

--- a/src/content/popup/render-popup.ts
+++ b/src/content/popup/render-popup.ts
@@ -141,6 +141,7 @@ export function renderPopup(
 
         const metadata = renderMetadata({
           fxData: options.fxData,
+          preferredUnits: options.preferredUnits,
           isCombinedResult: false,
           matchLen: 0,
           meta: options.meta,

--- a/src/content/popup/show-popup.ts
+++ b/src/content/popup/show-popup.ts
@@ -50,7 +50,6 @@ export type ShowPopupOptions = {
   fontFace?: FontFace;
   fontSize?: FontSize;
   fxData: ContentConfigParams['fx'];
-  preferredUnits: 'metric' | 'imperial';
   getCursorClearanceAndPos: () => { cursorClearance: Box; cursorPos?: Point };
   expandShortcuts?: ReadonlyArray<string>;
   interactive: boolean;
@@ -71,6 +70,7 @@ export type ShowPopupOptions = {
   posDisplay: PartOfSpeechDisplay;
   positionMode: PopupPositionMode;
   popupStyle: string;
+  preferredUnits: 'metric' | 'imperial';
   previousHeight?: number;
   safeArea: Box;
   showDefinitions: boolean;

--- a/src/content/popup/show-popup.ts
+++ b/src/content/popup/show-popup.ts
@@ -50,6 +50,7 @@ export type ShowPopupOptions = {
   fontFace?: FontFace;
   fontSize?: FontSize;
   fxData: ContentConfigParams['fx'];
+  preferredUnits: 'metric' | 'imperial';
   getCursorClearanceAndPos: () => { cursorClearance: Box; cursorPos?: Point };
   expandShortcuts?: ReadonlyArray<string>;
   interactive: boolean;

--- a/src/content/popup/words.ts
+++ b/src/content/popup/words.ts
@@ -58,6 +58,7 @@ export function renderWordEntries({
   if (options.meta) {
     const metadata = renderMetadata({
       fxData: options.fxData,
+      preferredUnits: options.preferredUnits,
       isCombinedResult: true,
       matchLen,
       meta: options.meta,

--- a/src/options/OptionsPage.tsx
+++ b/src/options/OptionsPage.tsx
@@ -12,6 +12,7 @@ import { KeyboardSettings } from './KeyboardSettings';
 import { PopupInteractivitySettings } from './PopupInteractivitySettings';
 import { PopupStyleSettings } from './PopupStyleSettings';
 import { PuckSettings } from './PuckSettings';
+import { UnitSettings } from './UnitSettings';
 
 type Props = {
   config: Config;
@@ -27,6 +28,7 @@ export function OptionsPage(props: Props) {
         <PopupStyleSettings config={props.config} />
         <PopupInteractivitySettings config={props.config} />
         <CurrencySettings config={props.config} />
+        <UnitSettings config={props.config} />
         {hasKeyboard && <KeyboardSettings config={props.config} />}
         <CopySettings config={props.config} />
         <PuckSettings config={props.config} />

--- a/src/options/UnitSettings.tsx
+++ b/src/options/UnitSettings.tsx
@@ -1,0 +1,40 @@
+import { useCallback } from 'preact/hooks';
+
+import type { Config } from '../common/config';
+import { useLocale } from '../common/i18n';
+
+import { SectionHeading } from './SectionHeading';
+import { UnitSettingsForm } from './UnitSettingsForm';
+import { useConfigValue } from './use-config-value';
+
+type Props = {
+  config: Config;
+};
+
+export function UnitSettings(props: Props) {
+  const { t } = useLocale();
+  const preferredUnits = useConfigValue(props.config, 'preferredUnits');
+
+  const onChangeUnits = useCallback(
+    (value: 'metric' | 'imperial') => {
+      props.config.preferredUnits = value;
+    },
+    [props.config]
+  );
+
+  if (!preferredUnits) {
+    return null;
+  }
+
+  return (
+    <>
+      <SectionHeading>{t('options_unit_conversion_heading')}</SectionHeading>
+      <div class="py-4">
+        <UnitSettingsForm
+          selectedUnits={preferredUnits}
+          onChange={onChangeUnits}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/options/UnitSettingsForm.tsx
+++ b/src/options/UnitSettingsForm.tsx
@@ -1,5 +1,7 @@
 import { useLocale } from '../common/i18n';
 
+import { NewBadge } from './NewBadge';
+
 type Props = {
   selectedUnits: 'metric' | 'imperial';
   onChange: (currency: string) => void;
@@ -16,6 +18,7 @@ export function UnitSettingsForm(props: Props) {
   return (
     <>
       <label for="preferredUnits">{t('options_units_label')}</label>
+      <NewBadge expiry={new Date('2024-09-30')} />
       <select
         id="preferredUnits"
         name="preferredUnits"

--- a/src/options/UnitSettingsForm.tsx
+++ b/src/options/UnitSettingsForm.tsx
@@ -1,0 +1,38 @@
+import { useLocale } from '../common/i18n';
+
+type Props = {
+  selectedUnits: 'metric' | 'imperial';
+  onChange: (currency: string) => void;
+};
+
+export function UnitSettingsForm(props: Props) {
+  const { t } = useLocale();
+
+  const options = [
+    ['metric', t('options_units_metric_label')],
+    ['imperial', t('options_units_imperial_label')],
+  ];
+
+  return (
+    <>
+      <label for="preferredUnits">{t('options_units_label')}</label>
+      <select
+        id="preferredUnits"
+        name="preferredUnits"
+        onInput={(event) => {
+          props.onChange(event.currentTarget.value);
+        }}
+      >
+        {options.map(([value, label]) => (
+          <option
+            key={value}
+            value={value}
+            selected={value === props.selectedUnits}
+          >
+            {label}
+          </option>
+        ))}
+      </select>
+    </>
+  );
+}


### PR DESCRIPTION
I will be the first person to admit that the imperial system is dumb, but it's what most Americans are accustomed to, and unfortunately I don't have an intuitive sense of how big a square meter is any more than I do 1畳, so hopefully this will be helpful to other SI-challenged folks like myself :).

It will still default to metric unless you set the setting to imperial.

@birtles and @SaltfishAmi, could use your help for the Japanese and Chinese l10ns if you don't mind (though in practice, I really doubt anybody will be using this in Chinese). Strings I need are:

`"metric"` — "メートル法" for Japanese?

`"imperial"` - "帝国単位" for Japanese?

`"Unit conversion"` (heading for the setting section with the drop down to select metric/imperial)

`"Preferred units"` (label on the drop down to select metric/imperial preference)

