### PR TITLE
fix: fix puck vanishing after dragging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ app.
 - Added supported for doing unit conversions to imperial units
   thanks to [@StarScape](https://github.com/StarScape)
   ([#1836](https://github.com/birchill/10ten-ja-reader/pull/1836))
+- Fixed a condition that could cause some preferences to be overwritten causing,
+  for example, the puck to suddenly disappear.
 - Fixed duplicate matching of names with both 新字体 and 旧字体
   ([#1830](https://github.com/birchill/10ten-ja-reader/issues/1830)).
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -609,21 +609,29 @@ browser.runtime.onMessage.addListener(
 
       case 'toggleDefinition':
         Bugsnag.leaveBreadcrumb('Toggling definitions on/off');
-        config.toggleReadingOnly();
+        void config.ready.then(() => {
+          config.toggleReadingOnly();
+        });
         break;
 
       case 'disableMouseInteraction':
         Bugsnag.leaveBreadcrumb('Disabling mouse interaction');
-        config.popupInteractive = false;
+        void config.ready.then(() => {
+          config.popupInteractive = false;
+        });
         break;
 
       case 'canHoverChanged':
         Bugsnag.leaveBreadcrumb('Changing hover ability setting', request);
-        config.canHover = request.value;
+        void config.ready.then(() => {
+          config.canHover = request.value;
+        });
         break;
 
       case 'puckStateChanged':
-        config.puckState = request.value;
+        void config.ready.then(() => {
+          config.puckState = request.value;
+        });
         break;
 
       case 'isDbUpdating':

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -179,7 +179,11 @@ export class Config {
 
     // If we have old mouse onboarding prefs, drop them
     if (this.settings.hasOwnProperty('hasDismissedMouseOnboarding')) {
-      await browser.storage.sync.remove('hasDismissedMouseOnboarding');
+      try {
+        await browser.storage.sync.remove('hasDismissedMouseOnboarding');
+      } catch {
+        // Ignore
+      }
     }
 
     if (
@@ -193,7 +197,11 @@ export class Config {
       delete (localSettings as Record<string, unknown>)
         .numLookupsWithMouseOnboarding;
       this.settings.localSettings = localSettings;
-      void browser.storage.local.set({ settings: localSettings });
+      try {
+        await browser.storage.local.set({ settings: localSettings });
+      } catch {
+        // Ignore
+      }
     }
   }
 


### PR DESCRIPTION
We've received a report of the puck occasionally vanishing after
dragging on the Brave browser (desktop).

I finally worked out a reliable STR for this:

1. Enable the puck
2. Open a web page with a lot of white space and position the puck in
   the white space.
3. Open the extensions management page in a separate window that you can
   see side-by-side.
4. Wait for the service worker to go idle.
5. Move the puck within the white space and then release it.

Here's what happens:

1. The background service worker is suspended.
2. After dragging the puck, the content script dispatches a
   "puckStateChanged" message to the background script.
3. The background service worker is woken up and immediately processes
   the "puckStateChanged" message by executing:

    ```js
    config.puckState = request.value
    ```

4. The setter for `puckState` performs:

    ```js
    const localSettings = { ...this.settings.localSettings };
    if (!value) {
      delete localSettings.puckState;
    } else {
      localSettings.puckState = value;
    }
    this.settings.localSettings = localSettings;

    void browser.storage.local.set({ settings: localSettings });

    ```

However, at this point, `readSettings()` has not yet completed and hence
`this.settings.localSettings` has not been populated.

As a result, `this.settings.localSettings.showPuck` gets set to
`undefined` which is treated as `"auto"` and, on a desktop browser
without a touch screen, that will end up being treated as `"hide"`.

Note that if the puck isn't positioned over white space then it will
trigger a word lookup before being released and the issue won't
reproduce.

To fix this, we need to wait for the config to load before trying to
mutate it.

We can't have async setters in JavaScript so we simply need to make sure
each call site waits before settings these properties, especially the
local settings.

In future, when we redo all the config setup using decorators (or some
other mechanism to avoid boilerplate), we should probably stop using
setters and introduce some sort of async `setValue` function that takes
care of waiting for the config to load before mutating it (or returning
values from it).

I don't _think_ we need to worry about setters from the options page
because the options page has its own `Config` object and doesn't get
suspended.
