### PR TITLE
fix: add される as inapplicable form for Ichidan verbs

### DIFF
--- a/src/background/deinflect.ts
+++ b/src/background/deinflect.ts
@@ -466,10 +466,13 @@ export function deinflect(word: string): CandidateWord[] {
       // られる and させる exist as separate rules that bypass the irrealis stem
       // type, we ignore the the rules with a to-type of IrrealisStem for the
       // passive and causative, i.e. the rules for れる and せる.
+      // Similarly, we need to ignore the rule for the causative passive, as
+      // the contraction of せられる to される is incorrect for Ichidan verbs.
       const inapplicableForm =
         type & Type.IrrealisStem &&
         (thisCandidate.reasonChains[0][0] == Reason.Passive ||
-          thisCandidate.reasonChains[0][0] == Reason.Causative);
+          thisCandidate.reasonChains[0][0] == Reason.Causative ||
+          thisCandidate.reasonChains[0][0] == Reason.CausativePassive);
 
       if (!inapplicableForm) {
         result.push({


### PR DESCRIPTION
The contraction of せられる to される is incorrect for Ichidan verbs.

Related to #1849.