### PR TITLE
fix: pass in shadowRoots to caretPositionFromPoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ app.
 
 ## [Unreleased]
 
+- Fixed handling of shadow DOM content in Chrome 128+ and Firefox Nightly.
 - Fixed matching of 0年
   ([#1912](https://github.com/birchill/10ten-ja-reader/pull/1912)).
 

--- a/tests/get-text.test.ts
+++ b/tests/get-text.test.ts
@@ -1474,16 +1474,10 @@ describe('getTextAtPoint', () => {
     // Chrome and Firefox will likely use different default fonts and
     // furthermore they follow different code paths.
     //
-    // On Chrome we create a mirror element for the text box and look up that
-    // instead. That might end up using different fonts for all we know.
-    // Furthermore, for the mirror element we end up applying the "previous
-    // character adjustment" (where we try to detect if caretPositionFromPoint
-    // _should_ have returned the previous character to what it did).
-    //
     // As a result, this may need tweaking from time to time. For now,
     // hopefully these values do the trick on all browsers and platforms we test
     // on.
-    const offset = isChromium() ? 13 : 15;
+    const offset = isChromium() ? 11 : 15;
 
     const result = getTextAtPoint({
       point: { x: bbox.left + offset, y: bbox.top + bbox.height / 2 },
@@ -1521,7 +1515,7 @@ describe('getTextAtPoint', () => {
     const bbox = inputNode.getBoundingClientRect();
 
     // See notes above about how we arrived at this offset.
-    const offset = isChromium() ? 13 : 15;
+    const offset = isChromium() ? 11 : 15;
 
     const result = getTextAtPoint({
       point: {
@@ -1566,7 +1560,7 @@ describe('getTextAtPoint', () => {
     const bbox = textAreaNode.getBoundingClientRect();
 
     // See notes above about how we arrived at this offset.
-    const offset = isChromium() ? 13 : 15;
+    const offset = isChromium() ? 10 : 15;
 
     const result = getTextAtPoint({ point: { x: bbox.left + offset, y: 5 } });
 

--- a/tests/playground.html
+++ b/tests/playground.html
@@ -269,7 +269,7 @@
           text-decoration-color: transparent;
           color: var(--cib-color-brand-tertiary-foreground);
           background: var(--cib-color-brand-tertiary-background);
-          outline: transparent solid  1px;
+          outline: transparent solid 1px;
         }
       `);
       innerShadowRoot.append(style);
@@ -283,7 +283,7 @@
       const explanationElem = document.createElement('div');
       innerShadowRoot.append(explanationElem);
       explanationElem.append(
-        '(In particular we want to check that towards the end of the line)'
+        '(In particular we want to check towards the end of the line)'
       );
     }
   </script>


### PR DESCRIPTION
The spec for caretPositionFromPoint has been updated to require
providing `shadowRoots` in order to dig into Shadow DOM content.[1]

This has been implemented in Chrome[2] and is due to ship in 128 (in beta
at the time of this patch).

It has also been implemented in Firefox[3] but is currently only enabled on
the Nightly channel.[4]

This API is quite annoying for extensions that simply want to scan all
the text in the document but I guess it makes sense for regular Web
apps.

[1] https://github.com/w3c/csswg-drafts/issues/9932
[2] https://issues.chromium.org/issues/41117286
[3] https://bugzilla.mozilla.org/show_bug.cgi?id=1889503
[4] https://searchfox.org/mozilla-central/rev/64f196824745c5db5ef7bb23725cfb9a41586149/modules/libpref/init/StaticPrefList.yaml#4742-4751
