### PR TITLE
fix: work around Chrome path length bug

### DIFF
--- a/src/content/popup/KanjiStrokeAnimation.tsx
+++ b/src/content/popup/KanjiStrokeAnimation.tsx
@@ -187,7 +187,15 @@ export function KanjiStrokeAnimation(props: Props) {
           ref={animatedStrokeContainer}
         >
           {subpaths.map((path, index) => (
-            <path key={index} d={path} fill="none" pathLength={100} />
+            <path
+              key={index}
+              d={path}
+              fill="none"
+              // We use 99.5 instead of 100 to work around path length
+              // inaccuracies in Chrome. Without this you'd occasionally see a
+              // dot at the end of a stroke that should be invisible.
+              pathLength={99.5}
+            />
           ))}
         </g>
       </svg>


### PR DESCRIPTION
This was supposed to be part of the original patch for the stroke
animation feature but we lost this commit when we rebased that branch.
