### PR TITLE
fix: prevent duplicate reasons in deinflection reason chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ app.
   thanks to [@maiself](https://github.com/maiself)
   ([#2014](https://github.com/birchill/10ten-ja-reader/pull/2014)).
 - Added handling for 戶 and 內 kyūjitai.
+- Fixed unreasonable matches caused by duplicates in the deinflection reason chain
+  ([#1966](https://github.com/birchill/10ten-ja-reader/issues/1966)).
 - Fixed sorting of deinflected results in some cases (e.g. 見とれる).
 - Fixed sorting when looking up kana in some cases (e.g. なる).
 

--- a/src/background/deinflect.test.ts
+++ b/src/background/deinflect.test.ts
@@ -23,6 +23,25 @@ describe('deinflect', () => {
     });
   });
 
+  it('does NOT allow duplicates in the reason chain', () => {
+    const cases = [
+      '見させさせる', // causative < causative
+      '見させてさせる', // causative < continuous < causative
+      '見ていている', // continuous < continuous
+      '見てさせている', // continuous < causative < continuous
+      '見とけとく', // -te oku < potential < -te oku
+    ];
+
+    for (const inflected of cases) {
+      const result = deinflect(inflected);
+      const match = result.find(
+        (candidate) =>
+          candidate.word === '見る' && candidate.type & WordType.IchidanVerb
+      );
+      expect(match).toBeUndefined();
+    }
+  });
+
   it('deinflects kana variations', () => {
     const cases = [
       ['走ります', '走る', [[Reason.Polite]], 2],

--- a/src/background/deinflect.ts
+++ b/src/background/deinflect.ts
@@ -508,6 +508,13 @@ export function deinflect(word: string): CandidateWord[] {
           continue;
         }
 
+        // Continue if the rule introduces a duplicate in the reason chain,
+        // as it wouldn't make sense grammatically.
+        const ruleReasons = new Set(rule.reasons);
+        if (thisCandidate.reasonChains.flat().some((r) => ruleReasons.has(r))) {
+          continue;
+        }
+
         // If we already have a candidate for this word with the same
         // 'to' type(s), expand the possible reasons by starting a new
         // reason chain.


### PR DESCRIPTION
_Related to #1966._

Any reason chains containing duplicate reasons will now be discarded to avoid unreasonable matches.