### PR TITLE
Fix touch not triggering the popup when `body` is unavailable during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ app.
 
 - Added support for irregular verb forms of 揺蕩う
   ([#1962](https://github.com/birchill/10ten-ja-reader/issues/1962)).
+- Made tap detection more reliable
+  thanks to [@maiself](https://github.com/maiself)
+  ([#2014](https://github.com/birchill/10ten-ja-reader/pull/2014)).
 
 ## [1.21.1] - 2024-09-14
 

--- a/src/content/touch-click-tracker.ts
+++ b/src/content/touch-click-tracker.ts
@@ -2,6 +2,7 @@ export class TouchClickTracker {
   private wasTouch = false;
   private ignoring = false;
   private disabled = false;
+  private clickHandlerRegistered = false;
   onTouchClick?: (event: MouseEvent) => void;
 
   constructor() {
@@ -49,15 +50,21 @@ export class TouchClickTracker {
     // click handler on the body element, iOS won't generate click events
     // from touch taps.
     document.body?.addEventListener('click', this.onClick);
+    this.clickHandlerRegistered = !!document.body;
   }
 
   private removeEventListeners() {
     window.removeEventListener('touchstart', this.onTouchStart);
     window.removeEventListener('touchend', this.onTouchEnd);
     document.body?.removeEventListener('click', this.onClick);
+    this.clickHandlerRegistered = false;
   }
 
   private onTouchStart() {
+    if (!this.clickHandlerRegistered) {
+      document.body?.addEventListener('click', this.onClick);
+      this.clickHandlerRegistered = !!document.body;
+    }
     this.wasTouch = false;
   }
 


### PR DESCRIPTION
Frequently the extension would have had to been disabled and re-enabled on mobile for taps to trigger the popup, this change is intended improve touch interaction reliability.