### PR TITLE
Add tooltip text for priority stars next to entries

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -497,6 +497,14 @@
     "message": "Tsugaru dialect",
     "description": "Label used to describe senses whose dialect is 'tsug' (Tsugaru dialect)"
   },
+  "entry_priority_label_high": {
+    "message": "Very common word",
+    "description": "Tooltip label used when user hovers over the filled star icon (★) to indicate a very frequent word"
+  },
+  "entry_priority_label_regular": {
+    "message": "Somewhat common word",
+    "description": "Tooltip label used when user hovers over the unfilled star icon (☆) to indicate a somewhat frequent word"
+  },
   "error_command_could_not_parse": {
     "message": "Could not parse command $command$",
     "placeholders": {
@@ -1984,7 +1992,7 @@
     "message": "Text"
   },
   "options_show_priority": {
-    "message": "Show indicators next to common (★) and somewhat common (☆) words",
+    "message": "Show indicators next to very common (★) and somewhat common (☆) words",
     "description": "Label for enabling the ★ and ☆ markers next to dictionary headwords to indicate they occur frequently  or somewhat frequently respectively"
   },
   "options_show_puck_label": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -497,6 +497,14 @@
     "message": "津軽弁",
     "description": "Label used to describe senses whose dialect is 'tsug' (Tsugaru dialect)"
   },
+  "entry_priority_label_high": {
+    "message": "非常に頻出",
+    "description": "Tooltip label used when user hovers over the filled star icon (★) to indicate a very frequent word"
+  },
+  "entry_priority_label_regular": {
+    "message": "やや頻出",
+    "description": "Tooltip label used when user hovers over the unfilled star icon (☆) to indicate a somewhat frequent word"
+  },
   "error_command_could_not_parse": {
     "message": "「​$command$​」の構文解析が失敗しました",
     "placeholders": {
@@ -1984,7 +1992,7 @@
     "message": "テキスト"
   },
   "options_show_priority": {
-    "message": "頻度の高い（★）又はある程度の高い（☆）のマーカーを表示",
+    "message": "非常に頻出する単語（★）およびやや頻出する単語（☆）のマーカーを表示",
     "description": "Label for enabling the ★ and ☆ markers next to dictionary headwords to indicate they occur frequently  or somewhat frequently respectively"
   },
   "options_show_puck_label": {

--- a/_locales/zh_hans/messages.json
+++ b/_locales/zh_hans/messages.json
@@ -497,6 +497,14 @@
     "message": "津轻方言",
     "description": "Label used to describe senses whose dialect is 'tsug' (Tsugaru dialect)"
   },
+  "entry_priority_label_high": {
+    "message": "高频词",
+    "description": "Tooltip label used when user hovers over the filled star icon (★) to indicate a very frequent word"
+  },
+  "entry_priority_label_regular": {
+    "message": "中高频词",
+    "description": "Tooltip label used when user hovers over the unfilled star icon (☆) to indicate a somewhat frequent word"
+  },
   "error_command_could_not_parse": {
     "message": "无法解析命令 $command$",
     "placeholders": {
@@ -1984,7 +1992,7 @@
     "message": "文本"
   },
   "options_show_priority": {
-    "message": "显示高频率（★）和较高频率（☆）的标志",
+    "message": "显示高频词（★）和中高频词（☆）的标志",
     "description": "Label for enabling the ★ and ☆ markers next to dictionary headwords to indicate they occur frequently  or somewhat frequently respectively"
   },
   "options_show_puck_label": {

--- a/src/content/popup/icons.ts
+++ b/src/content/popup/icons.ts
@@ -1,3 +1,5 @@
+import browser from 'webextension-polyfill';
+
 import { svg } from '../../utils/builder';
 
 export function renderBook(): SVGElement {
@@ -179,6 +181,11 @@ export function renderSpinner(): SVGElement {
 }
 
 export function renderStar(style: 'full' | 'hollow'): SVGElement {
+  const message =
+    style === 'full'
+      ? 'entry_priority_label_high'
+      : 'entry_priority_label_regular';
+
   return svg(
     'svg',
     {
@@ -186,6 +193,7 @@ export function renderStar(style: 'full' | 'hollow'): SVGElement {
       viewBox: '0 0 98.6 93.2',
       style: 'opacity: 0.5',
     },
+    svg('title', {}, browser.i18n.getMessage(message)),
     svg('path', {
       d:
         style === 'full'


### PR DESCRIPTION
This is a really simple change, but I added tooltip text for when you hover over the filled/unfilled star, which will say "High priority entry" or "Priority entry", respectively. I thought this was worth adding because I was at one point minorly confused on what the stars meant, and what the difference between them was. Let me know if there are better labels to describe these.

I also added entries for the Japanese and Chinese localizations. The Chinese was machined translated and quite probably wrong. The Japanese was my best guess and also quite probably wrong 🙂.

<img width="505" alt="image" src="https://github.com/user-attachments/assets/12670d97-e56e-4b03-b248-231e01643b6b">
