### PR TITLE
Various sorting fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ app.
   thanks to [@maiself](https://github.com/maiself)
   ([#2014](https://github.com/birchill/10ten-ja-reader/pull/2014)).
 - Added handling for 戶 and 內 kyūjitai.
+- Fixed sorting of deinflected results in some cases (e.g. 見とれる).
 
 ## [1.21.1] - 2024-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ app.
   ([#2014](https://github.com/birchill/10ten-ja-reader/pull/2014)).
 - Added handling for 戶 and 內 kyūjitai.
 - Fixed sorting of deinflected results in some cases (e.g. 見とれる).
+- Fixed sorting when looking up kana in some cases (e.g. なる).
 
 ## [1.21.1] - 2024-09-14
 


### PR DESCRIPTION
- fix: sort deinflected results by length
- fix: prioritize entries where most senses are "usually kana" when looking up by kana
