### PR TITLE
Drop 五段化 potential rule

### DIFF
--- a/src/background/deinflect.test.ts
+++ b/src/background/deinflect.test.ts
@@ -165,7 +165,6 @@ describe('deinflect', () => {
       ['発する', '発さない', [Reason.Irregular, Reason.Negative]],
       ['発する', '発さず', [Reason.Irregular, Reason.Zu]],
       ['発する', '発そう', [Reason.Irregular, Reason.Volitional]],
-      ['愛する', '愛せる', [Reason.Irregular, Reason.Potential]],
       ['愛する', '愛せば', [Reason.Irregular, Reason.Ba]],
       ['愛する', '愛せ', [Reason.Irregular, Reason.Imperative]],
       // ずる / vz class verbs

--- a/src/background/deinflect.ts
+++ b/src/background/deinflect.ts
@@ -533,21 +533,9 @@ export function deinflect(word: string): CandidateWord[] {
           continue;
         }
 
-        // Verify that adding the rule won't lead to duplicates or an unreasonable
-        // sequencing of reasons in the reason chain.
+        // Continue if the rule introduces a duplicate in the reason chain,
+        // as it wouldn't make sense grammatically.
         const ruleReasons = new Set(rule.reasons);
-
-        // Avoid matches such as 'potential < potential or passive' or
-        // 'potential < causative', which are grammatically incorrect.
-        // This is an issue when handling irregular forms like 罰せられる,
-        // where the structure could be misinterpreted as
-        // 'irregular < potential < potential or passive' instead of the correct
-        // 'irregular < potential or passive'.
-        if (ruleReasons.has(Reason.Potential)) {
-          ruleReasons.add(Reason.PotentialOrPassive);
-          ruleReasons.add(Reason.Causative);
-        }
-
         if (thisCandidate.reasonChains.flat().some((r) => ruleReasons.has(r))) {
           continue;
         }

--- a/src/background/deinflect.ts
+++ b/src/background/deinflect.ts
@@ -268,7 +268,6 @@ const deinflectRuleData: Array<
   ['せん', 'する', Type.Initial, Type.SuruVerb, [Reason.Negative]],
   ['せば', 'す', Type.Initial, Type.GodanVerb, [Reason.Ba]],
   ['せば', 'する', Type.Initial, Type.SpecialSuruVerb, [Reason.Irregular, Reason.Ba]],
-  ['せる', 'する', Type.IchidanVerb, Type.SpecialSuruVerb, [Reason.Irregular, Reason.Potential]],
   ['せよ', 'する', Type.Initial, Type.SuruVerb, [Reason.Imperative]],
   ['せる', 'す', Type.IchidanVerb, Type.GodanVerb, [Reason.Potential]],
   ['せる', '', Type.IchidanVerb, Type.IrrealisStem, [Reason.Causative]],


### PR DESCRIPTION
_Follow-up to #2038._

I encountered duplicate results for inputs like 宣せぬ or 宣せず, which stemmed from the following rule:
```ts
['せる', 'する', Type.IchidanVerb, Type.SpecialSuruVerb, [Reason.Irregular, Reason.Potential]],
```

After reading again [this resource](https://www.edrdg.org/wwwjdic/wwwverbinf.html#suru_tag) from JMdict, I realized that this rule is incorrect. Verbs undergoing 五段化 have either し得る or できる as their potential forms, not the す-Godan potential form (せる).

By dropping this incorrect rule, the issue is resolved, and we can also revert the previous commit that was intended to prevent invalid sequencing of potential forms.