### PR TITLE
fix: add 'negative -te' for 五段化 verbs

### DIFF
--- a/src/background/deinflect.test.ts
+++ b/src/background/deinflect.test.ts
@@ -163,6 +163,7 @@ describe('deinflect', () => {
       ['発する', '発しられる', [Reason.Irregular, Reason.PotentialOrPassive]],
       // 五段化
       ['発する', '発さない', [Reason.Irregular, Reason.Negative]],
+      ['発する', '発さないで', [Reason.Irregular, Reason.NegativeTe]],
       ['発する', '発さず', [Reason.Irregular, Reason.Zu]],
       ['発する', '発そう', [Reason.Irregular, Reason.Volitional]],
       ['愛する', '愛せば', [Reason.Irregular, Reason.Ba]],

--- a/src/background/deinflect.ts
+++ b/src/background/deinflect.ts
@@ -175,6 +175,7 @@ const deinflectRuleData: Array<
   ['ください', 'くださる', Type.Initial, Type.GodanVerb, [Reason.Imperative]],
   ['こさせる', 'くる', Type.IchidanVerb, Type.KuruVerb, [Reason.Causative]],
   ['こられる', 'くる', Type.IchidanVerb, Type.KuruVerb, [Reason.PotentialOrPassive]],
+  ['さないで', 'する', Type.Initial, Type.SpecialSuruVerb, [Reason.Irregular, Reason.NegativeTe]],
   ['ざるえぬ', '', Type.IAdj, Type.IrrealisStem, [Reason.ZaruWoEnai]],
   ['ざる得ぬ', '', Type.IAdj, Type.IrrealisStem, [Reason.ZaruWoEnai]],
   ['しないで', 'する', Type.Initial, Type.SuruVerb, [Reason.NegativeTe]],


### PR DESCRIPTION
Follow-up to #2038.

This adds the 'negative -te' form of 五段化 verbs (e.g. 宣さないで), which I missed in the initial PR.