### PR TITLE
Starting a wiki for documenting Japanese (de)inflection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - 'main'
+    paths-ignore:
+      - 'wiki/**'
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,22 @@
+name: Sync wiki
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'wiki/**'
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Synchronize wiki
+        run: bash sync-wiki.sh
+        working-directory: ./scripts
+        env:
+          WIKI_FOLDER: wiki
+          COMMIT_USERNAME: 'Wiki Sync'
+          COMMIT_EMAIL: 'actions@users.noreply.github.com'
+          COMMIT_MESSAGE: 'Synchronize wiki'
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/sync-wiki.sh
+++ b/scripts/sync-wiki.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Based on https://github.com/JoeIzzard/ghaction-wiki-sync
+
+set -e
+GITHUB_DOMAIN="$(echo "$GITHUB_SERVER_URL" | sed 's#https://\([\S]*\)#\1#')"
+WIKI="https://${GITHUB_REPOSITORY_OWNER}:${ACCESS_TOKEN}@${GITHUB_DOMAIN}/${GITHUB_REPOSITORY}.wiki.git"
+
+WIKI_CHECKOUT_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$WIKI_CHECKOUT_DIR"' EXIT
+
+echo "Cloning Wiki Repo..."
+git clone "$WIKI" "$WIKI_CHECKOUT_DIR"
+cd "$WIKI_CHECKOUT_DIR"
+
+echo "Cleaning..."
+rm -r -- *
+
+echo "Copy Files..."
+echo "-> Wiki Folder: ${WIKI_FOLDER}"
+cd "${GITHUB_WORKSPACE}"
+
+if [ ! -d "${GITHUB_WORKSPACE}/${WIKI_FOLDER}" ]; then
+    echo "Specified Wiki Folder Missing."
+    exit 1
+fi
+cp -a "${WIKI_FOLDER}/." "$WIKI_CHECKOUT_DIR"
+
+echo "Git Config..."
+echo "-> User: ${COMMIT_USERNAME}"
+echo "-> Email: ${COMMIT_EMAIL}"
+git config --file "${WIKI_CHECKOUT_DIR}/.git/config" user.email "${COMMIT_EMAIL}"
+git config --file "${WIKI_CHECKOUT_DIR}/.git/config" user.name "${COMMIT_USERNAME}"
+
+echo "Commit..."
+echo "-> Message: ${COMMIT_MESSAGE}"
+cd "$WIKI_CHECKOUT_DIR"
+git add -A
+if ! git diff --cached --exit-code > /dev/null; then
+    git commit -m "${COMMIT_MESSAGE}"
+    git push "$WIKI"
+else
+    echo "No changes to commit."
+fi
+
+echo "Finished!"

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,90 @@
+<div align="center">
+  <img
+    src="https://github.com/birchill/10ten-ja-reader/raw/main/images/10ten-ja-reader.svg"
+    alt="10ten Japanese Reader"
+    width="200"
+    height="200"
+  />
+  <h1>10tenウィキへ ようこそ！</h1>
+</div>
+
+This wiki aims to be a comprehensive resource for understanding the conjugation or
+inflection patterns of the Japanese language, with the ultimate goal of integrating
+the information collected here directly into 10ten, making it as accessible as possible
+for everyone.
+
+🚧 **Note:** This wiki is still in its early stages, and contributions are always
+appreciated!
+
+## 📚 How to contribute
+
+This wiki is synced with the `wiki/` folder of the code repository. If you’d like
+to contribute:
+
+1. **Fork and clone** the [repository](https://github.com/birchill/10ten-ja-reader).
+2. **Make your edits** to the Markdown files in the `wiki/` folder.
+3. **Submit a pull request** with your updates, improvements, or additions.
+
+Contributions of any size, from fixing small typos to adding detailed explanations,
+are valuable and welcome.
+
+## 📋 To-Do
+
+Out first goal is to create an article for each deinflection reason listed in the
+`Reason` enum from `src/background/deinflect.ts`. These articles will be made accessible
+alongside the deinflection chain displayed when viewing an inflected word entry.
+
+Each article should provide detailed explanations covering the following points:
+
+1. **The Auxiliary Word:**
+   Name the auxiliary word, e.g ない, たい, すぎる.
+2. **Stem Attachment:**
+   The type of stem the auxiliary word attaches to, e.g i-stem / masu-stem / 連用形,
+   a-stem / irrealis stem / 未然形.
+3. **Function in Context:**
+   Clarify the role or function of the auxiliary word in the specific grammatical
+   or contextual usage.
+4. **General Meaning:**
+   If appropriate, provide a broader overview of the auxiliary word’s general meaning
+   and usage across contexts.
+
+List of all deinflection reasons:
+
+- [ ]  Past
+- [ ]  Negative
+- [ ]  Zu
+- [ ]  Passive
+- [ ]  Causative
+- [ ]  CausativePassive
+- [ ]  Potential
+- [ ]  PotentialOrPassive
+- [ ]  Volitional
+- [ ]  MasuStem
+- [ ]  Te
+- [ ]  NegativeTe
+- [ ]  Continuous
+- [ ]  Imperative
+- [ ]  ImperativeNegative
+- [ ]  Polite
+- [ ]  PolitePast
+- [ ]  PoliteNegative
+- [ ]  PolitePastNegative
+- [ ]  PoliteVolitional
+- [ ]  Respectful
+- [ ]  Humble
+- [ ]  HumbleOrKansaiDialect
+- [ ]  Sou
+- [ ]  Sugiru
+- [ ]  Chau
+- [ ]  Toku
+- [ ]  Tara
+- [ ]  Tari
+- [ ]  Tai
+- [ ]  Ba
+- [ ]  Ki
+- [ ]  EruUru
+- [ ]  ZaruWoEnai
+- [ ]  Irregular
+- [ ]  Adv
+- [ ]  Noun
+- [ ]  SuruNoun


### PR DESCRIPTION
_As discussed in https://github.com/birchill/10ten-ja-reader/discussions/2048#discussioncomment-11008992._
_Related to #1970._

This is my proposal on how to handle documentation and explanations for the deinflection of 10ten.

It introduces a workflow that synchronizes the contents of a newly created `wiki` folder, whenever there is a push with changes to it, with the Git repository of the wiki.

As soon as the wiki is comprehensive enough, we can integrate the information in the Markdown files into 10ten.

I’d love to hear your thoughts on this approach!