### PR TITLE
Fix kanji references table overflow problem on small screens

### DIFF
--- a/src/content/popup/KanjiReferencesTable.tsx
+++ b/src/content/popup/KanjiReferencesTable.tsx
@@ -86,7 +86,7 @@ export function KanjiReferencesTable({ entry, kanjiReferences }: Props) {
   return (
     <div
       class={classes(
-        'tp-grid tp-grid-cols-[repeat(2,minmax(200px,1fr))] tp-gap-x-2',
+        'tp-grid tp-grid-cols-[repeat(2,minmax(min-content,1fr))] tp-gap-x-2',
         'max-[450px]:tp-grid-cols-none',
         '[--bg-overhang:8px]',
         '-tp-mx-[--bg-overhang] tp-w-[calc(100%+2*var(--bg-overhang))]'


### PR DESCRIPTION
This has been a problem starting from a while back on my iPhone mini screen: the kanji table overflows the x-axis.

Before:

![IMG_7064](https://github.com/user-attachments/assets/0f924abe-9ea7-4a1a-907b-51ca68da38f3)

With fix:

![IMG_7065](https://github.com/user-attachments/assets/f66edbb8-7efc-46ed-b5ed-693a31066d4f)
