### PR TITLE
fix: namespace popup positioning properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- Fixed the popup getting stuck to the top-left in Facebook
+  ([#2303](https://github.com/birchill/10ten-ja-reader/pull/2303)).
+
 ## [1.23.0] - 2025-01-23
 
 - Added precise conversion of Japanese era dates, including those preceding

--- a/src/content/popup/popup.css
+++ b/src/content/popup/popup.css
@@ -101,8 +101,8 @@
 
   .container {
     position: absolute;
-    left: var(--left, auto);
-    top: var(--top, auto);
+    left: var(--tenten-left, auto);
+    top: var(--tenten-top, auto);
 
     /*
     * Use the empirical maximum z-index since some sites (e.g. TimeTree) use this
@@ -156,30 +156,30 @@
   * on the popup.
   */
   .container.interactive .window {
-    max-height: var(--max-height, none);
+    max-height: var(--tenten-max-height, none);
   }
 
   .container:not(.interactive) {
-    max-height: var(--max-height, none);
+    max-height: var(--tenten-max-height, none);
     -webkit-mask-image: linear-gradient(
       to bottom,
-      black calc(var(--max-height) - 5px),
+      black calc(var(--tenten-max-height) - 5px),
       transparent
     );
     mask-image: linear-gradient(
       to bottom,
-      black calc(var(--max-height) - 5px),
+      black calc(var(--tenten-max-height) - 5px),
       transparent
     );
   }
 
   .container .window {
-    min-height: var(--min-height, none);
+    min-height: var(--tenten-min-height, none);
   }
 
   .window {
-    max-width: var(--max-width, 600px);
-    max-width: var(--max-width, min(600px, calc(100vw - 30px)));
+    max-width: var(--tenten-max-width, 600px);
+    max-width: var(--tenten-max-width, min(600px, calc(100vw - 30px)));
 
     contain: content;
     border-radius: 5px;

--- a/src/content/popup/render-popup.ts
+++ b/src/content/popup/render-popup.ts
@@ -331,10 +331,10 @@ function resetContainer({
 
   // Reset the container position and size so that we can consistently measure
   // the size of the popup.
-  host.style.removeProperty('--left');
-  host.style.removeProperty('--top');
-  host.style.removeProperty('--max-width');
-  host.style.removeProperty('--max-height');
+  host.style.removeProperty('--tenten-left');
+  host.style.removeProperty('--tenten-top');
+  host.style.removeProperty('--tenten-max-width');
+  host.style.removeProperty('--tenten-max-height');
 
   return windowDiv;
 }

--- a/src/content/popup/show-popup.ts
+++ b/src/content/popup/show-popup.ts
@@ -152,24 +152,30 @@ export function showPopup(
       wrapper.transform.baseVal.initialize(transform);
     }
   } else {
-    popup.style.setProperty('--left', `${popupPos.x}px`);
-    popup.style.setProperty('--top', `${popupPos.y}px`);
+    popup.style.setProperty('--tenten-left', `${popupPos.x}px`);
+    popup.style.setProperty('--tenten-top', `${popupPos.y}px`);
 
     if (popupPos.constrainWidth) {
-      popup.style.setProperty('--max-width', `${popupPos.constrainWidth}px`);
+      popup.style.setProperty(
+        '--tenten-max-width',
+        `${popupPos.constrainWidth}px`
+      );
     } else {
-      popup.style.removeProperty('--max-width');
+      popup.style.removeProperty('--tenten-max-width');
     }
 
     if (popupPos.constrainHeight) {
-      popup.style.removeProperty('--min-height');
-      popup.style.setProperty('--max-height', `${popupPos.constrainHeight}px`);
+      popup.style.removeProperty('--tenten-min-height');
+      popup.style.setProperty(
+        '--tenten-max-height',
+        `${popupPos.constrainHeight}px`
+      );
     } else if (minHeight) {
-      popup.style.setProperty('--min-height', `${minHeight}px`);
-      popup.style.removeProperty('--max-height');
+      popup.style.setProperty('--tenten-min-height', `${minHeight}px`);
+      popup.style.removeProperty('--tenten-max-height');
     } else {
-      popup.style.removeProperty('--min-height');
-      popup.style.removeProperty('--max-height');
+      popup.style.removeProperty('--tenten-min-height');
+      popup.style.removeProperty('--tenten-max-height');
     }
   }
 

--- a/tests/popups.html
+++ b/tests/popups.html
@@ -385,7 +385,7 @@
         });
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--max-height', '200px');
+        popup.style.setProperty('--tenten-max-height', '200px');
       }
 
       {
@@ -407,7 +407,7 @@
         );
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--max-height', '200px');
+        popup.style.setProperty('--tenten-max-height', '200px');
       }
 
       {
@@ -427,7 +427,7 @@
         });
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--max-height', '200px');
+        popup.style.setProperty('--tenten-max-height', '200px');
       }
 
       {
@@ -453,7 +453,7 @@
         );
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--max-height', '200px');
+        popup.style.setProperty('--tenten-max-height', '200px');
       }
     }
 
@@ -476,7 +476,7 @@
         });
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--min-height', '400px');
+        popup.style.setProperty('--tenten-min-height', '400px');
       }
 
       {
@@ -498,7 +498,7 @@
         );
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--min-height', '400px');
+        popup.style.setProperty('--tenten-min-height', '400px');
       }
 
       {
@@ -518,7 +518,7 @@
         });
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--min-height', '400px');
+        popup.style.setProperty('--tenten-min-height', '400px');
       }
 
       {
@@ -544,7 +544,7 @@
         );
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--min-height', '400px');
+        popup.style.setProperty('--tenten-min-height', '400px');
       }
 
       {
@@ -568,7 +568,7 @@
         });
 
         popup.classList.add('-inline');
-        popup.style.setProperty('--min-height', '400px');
+        popup.style.setProperty('--tenten-min-height', '400px');
       }
     }
 


### PR DESCRIPTION
Fixes #2303.

Facebook defines it's only `--left` and `--top` properties like so:

```css
--left {
  syntax: "*",
  inherits: false,
}
```

Because `inherits` is false, the popup fails to pick up the `--left` and
`--top` values we set on the shadow container.

This patch adds a `tenten-` prefix to these properties to (hopefully)
avoid clashes.
