### PR TITLE
fix: display correct Nelson radical information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- Fixed a bug when displaying Nelson radicals
+  ([#2315](https://github.com/birchill/10ten-ja-reader/pull/2315)).
+
 ## [1.24.2] - 2025-04-03
 
 - (Edge) Fix manifest to exclude `match_origin_as_fallback` property (this time

--- a/src/content/reference-value.ts
+++ b/src/content/reference-value.ts
@@ -13,7 +13,7 @@ export function getReferenceValue(
       // If the Nelson radical is empty, it means it's the same as the regular
       // radical so we should fall through to that branch.
       if (entry.rad.nelson) {
-        return `${entry.rad.nelson} ${entry.rad.nelson.c + 0x2eff}`;
+        return `${entry.rad.nelson.r} ${entry.rad.nelson.c}`;
       }
       // Fall through
     }


### PR DESCRIPTION
_Related to #2315._

With version 5 of the kanji data, the character is provided directly with no need for manual calculation from the radical number.