### PR TITLE
fix: re-add headword info to kana headwords

### DIFF
--- a/src/content/popup/Words/WordEntry.tsx
+++ b/src/content/popup/Words/WordEntry.tsx
@@ -197,6 +197,7 @@ export function WordEntry(props: WordEntryProps) {
                       kana={kana}
                       accentDisplay={props.config.accentDisplay}
                     />
+                    {!!kana.i?.length && <HeadwordInfo info={kana.i} />}
                     {props.config.showPriority && !!kana.p?.length && (
                       <PriorityMark priority={kana.p} />
                     )}


### PR DESCRIPTION
_Related to #2318._
_Fixes #2327._

It was erroneously dropped with the conversion of the words tab to Preact (5e24ba938a0dc1e1fba50bfa11c56cf15136a400).