### PR TITLE
Add Shift as a possible keybinding for hold to show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ app.
 
 ## [Unreleased]
 
+- Added Shift as a possible keybinding for hold to show
+  ([#2409](https://github.com/birchill/10ten-ja-reader/pull/2409)).
 - Fixed a bug when displaying Nelson radicals
   ([#2315](https://github.com/birchill/10ten-ja-reader/pull/2315)).
 - Fixed a bug that prevented the flash animation after copying an entry from playing

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1609,6 +1609,10 @@
       "lastcheck": { "content": "$1", "example": "2019-10-12" }
     }
   },
+  "options_lookup_kanji_tooltip": {
+    "message": "Shift cannot be selected for kanji lookup when it is a hold-to-show key.",
+    "description": "Tooltip explaining why the checkbox for activating Shift for kanji lookup is disabled"
+  },
   "options_lookup_puck_heading": {
     "message": "Lookup puck",
     "description": "Heading for the section containing options controlling the lookup puck used on touch devices"

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1609,6 +1609,10 @@
       "lastcheck": { "content": "$1", "example": "2019-10-12" }
     }
   },
+  "options_lookup_kanji_tooltip": {
+    "message": "「Shift」は、「ポップアップを表示」のキーとして設定されている場合、「漢字の結果のみ調べる」用には選択できません。",
+    "description": "Tooltip explaining why the checkbox for activating Shift for kanji lookup is disabled"
+  },
   "options_lookup_puck_heading": {
     "message": "検索用の丸いボタン",
     "description": "Heading for the section containing options controlling the lookup puck used on touch devices"

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1605,6 +1605,10 @@
       "lastcheck": { "content": "$1", "example": "2019-10-12" }
     }
   },
+  "options_lookup_kanji_tooltip": {
+    "message": "当 Shift 键被设为“显示弹出窗口”键时，不能将其用于“只查询汉字结果”。",
+    "description": "Tooltip explaining why the checkbox for activating Shift for kanji lookup is disabled"
+  },
   "options_lookup_puck_heading": {
     "message": "用于触摸屏的圆形按钮",
     "description": "Heading for the section containing options controlling the lookup puck used on touch devices"

--- a/src/common/config.test.ts
+++ b/src/common/config.test.ts
@@ -390,4 +390,11 @@ describe('Config', () => {
     await noChangePromise;
     expect(config.dictLang).toEqual('pt');
   });
+
+  it('removes Shift from kanjiLookup when used as hold-to-show key', () => {
+    const config = new Config();
+    config.holdToShowKeys = 'Alt+Shift';
+    config.updateKeys({ kanjiLookup: ['Shift'] });
+    expect(config.keys.kanjiLookup).not.toContain('Shift');
+  });
 });

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -266,15 +266,21 @@ export class Config {
           delete updatedChanges.kanjiReferencesV2;
           break;
 
-        // In some cases, the pinPopup key is calculated from the holdToShowKeys
-        // value so we might need to report that too.
+        // In some cases, the pinPopup and kanjiLookup keys are calculated from
+        // the holdToShow(Image)Keys value so we might need to report that too.
         case 'holdToShowKeys':
+        case 'holdToShowImageKeys':
           // If...
           if (
             // We are already reporting a change to `keys`, or
             Object.keys(updatedChanges).includes('keys') ||
-            // The pinPopup key is already explicitly set
-            this.settings.keys?.pinPopup
+            // The pinPopup key is already explicitly set and
+            (this.settings.keys?.pinPopup &&
+              // The change doesn't involve the shift key
+              !(
+                updatedChanges[key].newValue?.includes('Shift') ||
+                updatedChanges[key].oldValue?.includes('Shift')
+              ))
           ) {
             // ... we don't need to report a change
             break;
@@ -961,6 +967,15 @@ export class Config {
           keys.pinPopup = [holdToShowKey];
         }
       }
+    }
+
+    // If shift is activated as a hold to show key, we need to deactivate the
+    // shift key for kanji lookups.
+    if (
+      this.holdToShowKeys?.includes('Shift') ||
+      this.holdToShowImageKeys?.includes('Shift')
+    ) {
+      keys.kanjiLookup = keys.kanjiLookup.filter((key) => key !== 'Shift');
     }
 
     // When we first released the `expandPopup` key ('x') we didn't notice

--- a/src/common/content-config-params.ts
+++ b/src/common/content-config-params.ts
@@ -94,10 +94,10 @@ export interface ContentConfigParams {
   // Modifier keys which must be held down in order for the pop-up to shown.
   //
   // This should be a Set but Chrome can't send Sets by sendMessage :(
-  holdToShowKeys: Array<'Alt' | 'Ctrl'>;
+  holdToShowKeys: Array<'Alt' | 'Ctrl' | 'Shift'>;
 
   // As above but specifically for images.
-  holdToShowImageKeys: Array<'Alt' | 'Ctrl'>;
+  holdToShowImageKeys: Array<'Alt' | 'Ctrl' | 'Shift'>;
 
   // References to show in the kanji view.
   kanjiReferences: Array<import('./refs').ReferenceAbbreviation>;

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1266,7 +1266,7 @@ export class ContentHandler {
   // Test if an incoming keyboard event matches the hold-to-show key sequence.
   isHoldToShowKeyStroke(event: KeyboardEvent): HoldToShowKeyType {
     // Check if it is a modifier at all
-    if (!['Alt', 'AltGraph', 'Control'].includes(event.key)) {
+    if (!['Alt', 'AltGraph', 'Control', 'Shift'].includes(event.key)) {
       return HoldToShowKeyType.None;
     }
 
@@ -1302,6 +1302,9 @@ export class ContentHandler {
         return false;
       }
       if (this.config[setting].includes('Ctrl') && !event.ctrlKey) {
+        return false;
+      }
+      if (this.config[setting].includes('Shift') && !event.shiftKey) {
         return false;
       }
 

--- a/src/options/KeyboardSettings.tsx
+++ b/src/options/KeyboardSettings.tsx
@@ -233,7 +233,11 @@ function useHoldToShowKeysSetting(
       typeof value === 'string'
         ? value.split('+').map((part) => part.trim().toLowerCase())
         : [];
-    return { ctrl: parts.includes('ctrl'), alt: parts.includes('alt') };
+    return {
+      ctrl: parts.includes('ctrl'),
+      alt: parts.includes('alt'),
+      shift: parts.includes('shift'),
+    };
   }, [value]);
 
   const setValue = useCallback(
@@ -244,6 +248,9 @@ function useHoldToShowKeysSetting(
       }
       if (value.alt) {
         parts.push('Alt');
+      }
+      if (value.shift) {
+        parts.push('Shift');
       }
       config[key] = parts.length ? parts.join('+') : null;
     },

--- a/src/options/KeyboardSettingsForm.fixture.tsx
+++ b/src/options/KeyboardSettingsForm.fixture.tsx
@@ -45,12 +45,14 @@ export default function KeyboardSettingsFormFixture() {
   // Hold-to-show keys
 
   const [holdToShowKeys, setHoldToShowKeys] = useState({
-    ctrl: true,
-    alt: false,
+    ctrl: false,
+    alt: true,
+    shift: true,
   });
   const [holdToShowImageKeys, setHoldToShowImageKeys] = useState({
     ctrl: true,
     alt: false,
+    shift: false,
   });
 
   // Popup keys

--- a/src/options/KeyboardSettingsForm.tsx
+++ b/src/options/KeyboardSettingsForm.tsx
@@ -46,6 +46,9 @@ export function KeyboardSettingsForm(props: Props) {
         isMac={props.isMac}
         keys={props.popupKeys}
         onUpdateKey={props.onUpdatePopupKey}
+        isHoldToShowShiftEnabled={
+          props.holdToShowKeys.shift || props.holdToShowImageKeys.shift
+        }
       />
     </>
   );

--- a/src/options/PopupKeysForm.tsx
+++ b/src/options/PopupKeysForm.tsx
@@ -14,6 +14,7 @@ type Props = {
   isMac: boolean;
   keys: StoredKeyboardKeys;
   onUpdateKey: (key: keyof StoredKeyboardKeys, value: Array<string>) => void;
+  isHoldToShowShiftEnabled: boolean;
 };
 
 export function PopupKeysForm(props: Props) {
@@ -33,6 +34,7 @@ export function PopupKeysForm(props: Props) {
           name={key.name}
           onUpdate={props.onUpdateKey}
           value={props.keys[key.name]}
+          isHoldToShowShiftEnabled={props.isHoldToShowShiftEnabled}
         />
       ))}
     </div>
@@ -46,6 +48,7 @@ function PopupKey(props: {
   name: keyof StoredKeyboardKeys;
   onUpdate: (key: keyof StoredKeyboardKeys, value: Array<string>) => void;
   value: Array<string>;
+  isHoldToShowShiftEnabled: boolean;
 }) {
   const { t } = useLocale();
 
@@ -72,6 +75,8 @@ function PopupKey(props: {
             .slice(0, i)
             .some((key) => props.value.includes(key));
           const orEnabled = checked && priorEnabled;
+          const disableKanjiLookup =
+            props.name === 'kanjiLookup' && props.isHoldToShowShiftEnabled;
 
           return (
             <>
@@ -80,7 +85,17 @@ function PopupKey(props: {
                   {t('options_key_alternative')}
                 </span>
               )}
-              <KeyCheckbox checked={checked} onClick={onClick} value={key}>
+              <KeyCheckbox
+                checked={checked}
+                onClick={onClick}
+                value={key}
+                disabled={disableKanjiLookup}
+                title={
+                  disableKanjiLookup
+                    ? 'Shift cannot be selected for Kanji Lookup when it is a hold-to-show key.'
+                    : undefined
+                }
+              >
                 {props.name === 'movePopupDownOrUp' ? (
                   (() => {
                     const [down, up] = key.split(',', 2);

--- a/src/options/ShowPopupKeysForm.tsx
+++ b/src/options/ShowPopupKeysForm.tsx
@@ -4,7 +4,7 @@ import { useLocale } from '../common/i18n';
 
 import { KeyBox, KeyCheckbox } from './KeyBox';
 
-export type HoldToShowSetting = { alt: boolean; ctrl: boolean };
+export type HoldToShowSetting = { alt: boolean; ctrl: boolean; shift: boolean };
 
 type Props = {
   isMac: boolean;
@@ -65,10 +65,12 @@ type KeyCheckboxesProps = {
 function KeyCheckboxes(props: KeyCheckboxesProps) {
   const altRef = useRef<HTMLInputElement>(null);
   const ctrlRef = useRef<HTMLInputElement>(null);
+  const shiftRef = useRef<HTMLInputElement>(null);
   const onChange = () => {
     props.onChange({
       alt: altRef.current?.checked ?? false,
       ctrl: ctrlRef.current?.checked ?? false,
+      shift: shiftRef.current?.checked ?? false,
     });
   };
 
@@ -82,6 +84,22 @@ function KeyCheckboxes(props: KeyCheckboxesProps) {
       </span>
       <KeyCheckbox checked={props.value.ctrl} onClick={onChange} ref={ctrlRef}>
         <KeyBox label="Ctrl" isMac={props.isMac} />
+      </KeyCheckbox>
+      <span
+        class={
+          !props.value.shift || (!props.value.alt && !props.value.ctrl)
+            ? 'opacity-50'
+            : ''
+        }
+      >
+        +
+      </span>
+      <KeyCheckbox
+        checked={props.value.shift}
+        onClick={onChange}
+        ref={shiftRef}
+      >
+        <KeyBox label="Shift" isMac={props.isMac} />
       </KeyCheckbox>
     </div>
   );


### PR DESCRIPTION
_Closes #2408, closes #1269._

This PR adds the option to use the Shift key to show the popup. However, this introduces a conflict with the `Switch dictionaries` and `Lookup kanji results only` options, as they also utilize the Shift key. In my opinion, the overlap with `Switch dictionaries` is not an issue and actually results in a convenient workflow for users who have Shift for hold to show activated  and frequently switch dictionaries.

To address the conflict with `Lookup kanji results only` it is automatically deactivated when the Shift key is set to `hold to show` and the option remains disabled as long as Shift is assigned for this.

I'm wondering whether we should allow users to choose a different key for `Lookup kanji results only`, so it would still be possible to activate it when Shift is used to show the popup.

**Todo:**
- [x] Localize tooltip
- [x] Changelog