### PR TITLE
fix: fix Tailwind utility classes not reacting to the font size setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ app.
   ([#2315](https://github.com/birchill/10ten-ja-reader/pull/2315)).
 - Fixed a bug that prevented the flash animation after copying an entry from playing
   ([#2415](https://github.com/birchill/10ten-ja-reader/pull/2415)).
+- Fixed a bug where changing the font size in the settings wouldn't apply to the `Kanji` and `Names` tabs
+  ([#2418](https://github.com/birchill/10ten-ja-reader/pull/2418)).
 
 ## [1.24.2] - 2025-04-03
 

--- a/src/content/popup/popup.css
+++ b/src/content/popup/popup.css
@@ -20,7 +20,14 @@
       color: white;
     }
   }
+}
 
+/*
+ * Theme variables referencing other variables have to be inlined, otherwise,
+ * updates to the referenced variables will not propagate as expected.
+ * See https://tailwindcss.com/docs/theme#referencing-other-variables
+ */
+@theme inline {
   /**
    * Compare to
    * https://github.com/tailwindlabs/tailwindcss/blob/48957c541122f77ff22a09f81545b14ae7d7ae80/packages/tailwindcss/theme.css#L299-L324


### PR DESCRIPTION
This fixes a bug where changing the font size in the settings wouldn't affect the kanji and names tabs.