### PR TITLE
fix: fix word entry copy highlighting

### DIFF
--- a/src/content/popup/Words/WordEntry.tsx
+++ b/src/content/popup/Words/WordEntry.tsx
@@ -127,7 +127,17 @@ export function WordEntry(props: WordEntryProps) {
   }
 
   return (
-    <div class="entry" onPointerUp={props.onPointerUp} onClick={props.onClick}>
+    <div
+      class={classes(
+        'entry',
+        // See comment in KanjiEntry.tsx about the future plans for these
+        // CSS classes.
+        props.selectState === 'selected' && '-selected',
+        props.selectState === 'flash' && '-flash'
+      )}
+      onPointerUp={props.onPointerUp}
+      onClick={props.onClick}
+    >
       <div>
         {searchOnlyMatch && (
           <div class="tp:mb-1 tp:text-sm tp:opacity-70">


### PR DESCRIPTION
Looks like we missed this in
https://github.com/birchill/10ten-ja-reader/commit/5e24ba938a0dc1e1fba50bfa11c56cf15136a400

This should be fixed by #2416 but I'm putting this up here in case we can't
merge that PR before the next release.
