### PR TITLE
fix: remove redundant snap settings causing random scroll jumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- (Safari) Fixed random jumps in the words list
+  ([#2457](https://github.com/birchill/10ten-ja-reader/issues/2457)).
+
 ## [1.25.0] - 2025-07-04
 
 - Added support for looking up subtitles in Plex video content

--- a/src/content/popup/render-popup.ts
+++ b/src/content/popup/render-popup.ts
@@ -119,7 +119,7 @@ export function renderPopup(
         contentContainer.append(
           html(
             'div',
-            { class: 'expandable tp:snap-y tp:snap-mandatory' },
+            { class: 'expandable' },
             renderWordEntries({
               entries: resultToShow.data,
               matchLen: resultToShow.matchLen,


### PR DESCRIPTION
_Fixes #2457, fixes #2460._

Setting `tp:snap-y` and `tp:snap-mandatory` in `words.ts` is redundant and overrides the behavior in `expandable.ts`.
In Safari, this caused the Words list to scroll to random positions.