### PR TITLE
Update pointer move handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ app.
 - Added references for
   [The Kodansha Kanji Dictionary](https://www.kanji.org/dictionaries/KKD/kaneirev.htm).
 - Improved scanning of ruby transcription text.
+- Made popup work for Notion popups like the calendar
+  ([#2530](https://github.com/birchill/10ten-ja-reader/issues/2530)).
 
 ## [1.25.1] - 2025-07-22
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -169,10 +169,10 @@ export class ContentHandler {
   // the popup.
   private currentPagePoint: Point | undefined;
 
-  // We keep track of the last element that was the target of a mouse move so
+  // We keep track of the last element that was the target of a pointer move so
   // that we can popup the window later using its properties.
-  private lastMouseTarget: Element | null = null;
-  private lastMouseMoveScreenPoint = { x: -1, y: -1 };
+  private lastPointerTarget: Element | null = null;
+  private lastPointerMoveScreenPoint = { x: -1, y: -1 };
 
   // Safari-only redundant pointermove/mousemove event handling
   //
@@ -637,8 +637,8 @@ export class ContentHandler {
           event.metaKey ||
           event.ctrlKey ||
           this.ignoreNextPointerMove) &&
-        this.lastMouseMoveScreenPoint.x === event.clientX &&
-        this.lastMouseMoveScreenPoint.y === event.clientY
+        this.lastPointerMoveScreenPoint.x === event.clientX &&
+        this.lastPointerMoveScreenPoint.y === event.clientY
       ) {
         // We need to ignore the mousemove event corresponding to the keyup
         // event too.
@@ -648,7 +648,7 @@ export class ContentHandler {
 
       this.ignoreNextPointerMove = false;
     }
-    this.lastMouseMoveScreenPoint = { x: event.clientX, y: event.clientY };
+    this.lastPointerMoveScreenPoint = { x: event.clientX, y: event.clientY };
 
     // If we start moving the mouse, we should stop trying to recognize a tap on
     // the "pin" key as such since it's no longer a tap (and very often these
@@ -698,7 +698,7 @@ export class ContentHandler {
       !isTouchClickEvent(event) &&
       this.popupState?.display.mode === 'pinned'
     ) {
-      this.lastMouseTarget = event.target;
+      this.lastPointerTarget = event.target;
       return;
     }
 
@@ -764,7 +764,7 @@ export class ContentHandler {
         x: event.clientX,
         y: event.clientY,
       });
-      this.lastMouseTarget = event.target;
+      this.lastPointerTarget = event.target;
       return;
     }
 
@@ -789,7 +789,7 @@ export class ContentHandler {
 
     // Record the last mouse target in case we need to trigger the popup
     // again.
-    this.lastMouseTarget = event.target;
+    this.lastPointerTarget = event.target;
 
     void this.tryToUpdatePopup({
       fromPuck: isPuckPointerEvent(event),
@@ -1006,14 +1006,14 @@ export class ContentHandler {
       // We don't do this when the there is a text box in focus because we
       // we risk interfering with the text selection when, for example, the
       // hold-to-show key is Ctrl and the user presses Ctrl+V etc.
-      if (!textBoxInFocus && this.currentPagePoint && this.lastMouseTarget) {
+      if (!textBoxInFocus && this.currentPagePoint && this.lastPointerTarget) {
         void this.tryToUpdatePopup({
           fromPuck: false,
           fromTouch: false,
           matchText: !!(matchedHoldToShowKeys & HoldToShowKeyType.Text),
           matchImages: !!(matchedHoldToShowKeys & HoldToShowKeyType.Images),
           screenPoint: toScreenCoords(this.currentPagePoint),
-          eventElement: this.lastMouseTarget,
+          eventElement: this.lastPointerTarget,
           dictMode: 'default',
         });
       }
@@ -1095,7 +1095,7 @@ export class ContentHandler {
     } else if (textBoxInFocus) {
       // If we are focussed on a textbox and the keystroke wasn't one we handle
       // one, enter typing mode and hide the pop-up.
-      this.clearResult({ currentElement: this.lastMouseTarget });
+      this.clearResult({ currentElement: this.lastPointerTarget });
       this.typingMode = true;
     }
   }
@@ -1259,7 +1259,7 @@ export class ContentHandler {
 
     // If we entered typing mode clear the highlight.
     if (this.typingMode) {
-      this.clearResult({ currentElement: this.lastMouseTarget });
+      this.clearResult({ currentElement: this.lastPointerTarget });
     }
   }
 
@@ -1523,7 +1523,7 @@ export class ContentHandler {
 
           // We are doing a lookup based on an iframe's contents so we should
           // clear any mouse target we previously stored.
-          this.lastMouseTarget = null;
+          this.lastPointerTarget = null;
 
           const meta = request.meta as SelectionMeta | undefined;
           void this.lookupText({
@@ -1814,7 +1814,7 @@ export class ContentHandler {
   }: { currentElement?: Element | null } = {}) {
     this.currentTextRange = undefined;
     this.currentPagePoint = undefined;
-    this.lastMouseTarget = null;
+    this.lastPointerTarget = null;
     this.copyState = { kind: 'inactive' };
 
     clearPopupTimeout(this.popupState);
@@ -2031,7 +2031,7 @@ export class ContentHandler {
     }
 
     if (!queryResult && !meta) {
-      this.clearResult({ currentElement: this.lastMouseTarget });
+      this.clearResult({ currentElement: this.lastPointerTarget });
       return;
     }
 
@@ -2187,7 +2187,7 @@ export class ContentHandler {
     }
 
     if (!this.currentSearchResult && !this.currentLookupParams?.meta) {
-      this.clearResult({ currentElement: this.lastMouseTarget });
+      this.clearResult({ currentElement: this.lastPointerTarget });
       return;
     }
 
@@ -2245,7 +2245,7 @@ export class ContentHandler {
         this.enterCopyMode({ trigger, index }),
       onCopy: (copyType: CopyType) => this.copyCurrentEntry(copyType),
       onClosePopup: () => {
-        this.clearResult({ currentElement: this.lastMouseTarget });
+        this.clearResult({ currentElement: this.lastPointerTarget });
       },
       onShowSettings: () => {
         browser.runtime.sendMessage({ type: 'options' }).catch(() => {
@@ -2280,7 +2280,7 @@ export class ContentHandler {
 
     const showPopupResult = showPopup(this.currentSearchResult, popupOptions);
     if (!showPopupResult) {
-      this.clearResult({ currentElement: this.lastMouseTarget });
+      this.clearResult({ currentElement: this.lastPointerTarget });
       return;
     }
     const { size: popupSize, pos: popupPos } = showPopupResult;
@@ -2511,13 +2511,13 @@ export class ContentHandler {
     // Unfortunately this won't necessarily help if the user has since moused
     // over an iframe since our last recorded mouse position and target element
     // will be based on the last mousemove event we received in _this_ frame.
-    if (this.lastMouseTarget) {
+    if (this.lastPointerTarget) {
       const mouseMoveEvent = new MouseEvent('mousemove', {
         bubbles: true,
-        screenX: this.lastMouseMoveScreenPoint.x,
-        screenY: this.lastMouseMoveScreenPoint.y,
-        clientX: this.lastMouseMoveScreenPoint.x,
-        clientY: this.lastMouseMoveScreenPoint.y,
+        screenX: this.lastPointerMoveScreenPoint.x,
+        screenY: this.lastPointerMoveScreenPoint.y,
+        clientX: this.lastPointerMoveScreenPoint.x,
+        clientY: this.lastPointerMoveScreenPoint.y,
         ctrlKey: false,
         shiftKey: false,
         altKey: false,
@@ -2525,7 +2525,7 @@ export class ContentHandler {
         button: 0,
         buttons: 0,
       });
-      this.lastMouseTarget.dispatchEvent(mouseMoveEvent);
+      this.lastPointerTarget.dispatchEvent(mouseMoveEvent);
     }
   }
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -692,9 +692,9 @@ export class ContentHandler {
       return;
     }
 
-    // We don't know how to deal with anything that's not an element
-    if (!(event.target instanceof Element)) {
-      return;
+    let targetElement: Element | null = null;
+    if (event.target instanceof Element) {
+      targetElement = event.target;
     }
 
     // Ignore mouse moves if we are pinned
@@ -702,7 +702,7 @@ export class ContentHandler {
       !isTouchClickEvent(event) &&
       this.popupState?.display.mode === 'pinned'
     ) {
-      this.lastPointerTarget = event.target;
+      this.lastPointerTarget = targetElement;
       return;
     }
 
@@ -758,7 +758,7 @@ export class ContentHandler {
     // want to close the popup.)
     if (!contentsToMatch && this.popupState?.display.mode !== 'hover') {
       if (this.popupState) {
-        this.clearResult({ currentElement: event.target });
+        this.clearResult({ currentElement: targetElement });
       }
 
       // We still want to set the current position and element information so
@@ -768,7 +768,7 @@ export class ContentHandler {
         x: event.clientX,
         y: event.clientY,
       });
-      this.lastPointerTarget = event.target;
+      this.lastPointerTarget = targetElement;
       return;
     }
 
@@ -781,7 +781,7 @@ export class ContentHandler {
 
     // If the mouse is moving too quickly, don't show the popup
     if (this.shouldThrottlePopup(event)) {
-      this.clearResult({ currentElement: event.target });
+      this.clearResult({ currentElement: targetElement });
       return;
     }
 
@@ -793,7 +793,7 @@ export class ContentHandler {
 
     // Record the last mouse target in case we need to trigger the popup
     // again.
-    this.lastPointerTarget = event.target;
+    this.lastPointerTarget = targetElement;
 
     void this.tryToUpdatePopup({
       fromPuck: isPuckPointerEvent(event),
@@ -801,7 +801,7 @@ export class ContentHandler {
       matchText,
       matchImages,
       screenPoint: { x: event.clientX, y: event.clientY },
-      eventElement: event.target,
+      eventElement: targetElement,
       dictMode,
     });
   }
@@ -1861,7 +1861,10 @@ export class ContentHandler {
     matchText: boolean;
     matchImages: boolean;
     screenPoint: Point;
-    eventElement: Element;
+    // The `eventElement` is only used for determining if we need to preserve
+    // the scroll position when clearing an existing result by determining if we
+    // are still interacting with the same element.
+    eventElement: Element | null;
     dictMode: 'default' | 'kanji';
   }) {
     const textAtPoint = getTextAtPoint({
@@ -1916,7 +1919,7 @@ export class ContentHandler {
     const pageTargetProps = getPageTargetProps({
       fromPuck,
       fromTouch,
-      target: eventElement,
+      target: textAtPoint.startElement,
       textRange: textAtPoint?.textRange || undefined,
     });
 

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -285,7 +285,9 @@ export class ContentHandler {
     this.onConfigChange = this.onConfigChange.bind(this);
     this.config.addListener(this.onConfigChange);
 
-    window.addEventListener('pointermove', this.onPointerMove);
+    window.addEventListener('pointermove', this.onPointerMove, {
+      capture: true,
+    });
     window.addEventListener('mousedown', this.onMouseDown);
     window.addEventListener('keydown', this.onKeyDown, { capture: true });
     window.addEventListener('keyup', this.onKeyUp, { capture: true });
@@ -522,7 +524,9 @@ export class ContentHandler {
   detach() {
     this.config.removeListener(this.onConfigChange);
 
-    window.removeEventListener('pointermove', this.onPointerMove);
+    window.removeEventListener('pointermove', this.onPointerMove, {
+      capture: true,
+    });
     window.removeEventListener('mousedown', this.onMouseDown);
     window.removeEventListener('keydown', this.onKeyDown, { capture: true });
     window.removeEventListener('keyup', this.onKeyUp, { capture: true });

--- a/src/content/get-cursor-position.ts
+++ b/src/content/get-cursor-position.ts
@@ -652,9 +652,8 @@ function caretRangeFromPoint({
     return null;
   }
 
-  // Unlike `document.caretPositionFromPoint` in Gecko,
-  // `document.caretRangeFromPoint` in Blink/WebKit doesn't dig into shadow DOM
-  // so we need to do it manually.
+  // `document.caretRangeFromPoint` doesn't dig into shadow DOM so we need to
+  // do it manually.
   range = expandShadowDomInRange({ range, point });
 
   // Check if we are now pointing at an input text node.

--- a/src/content/scan-text.ts
+++ b/src/content/scan-text.ts
@@ -1,8 +1,22 @@
 import { nonJapaneseChar } from '../utils/char-range';
 
 import type { CursorPosition } from './get-cursor-position';
-import type { GetTextAtPointResult } from './get-text';
-import { extractGetTextMetadata, lookForMetadata } from './meta';
+import {
+  type SelectionMeta,
+  extractGetTextMetadata,
+  lookForMetadata,
+} from './meta';
+import type { TextRange } from './text-range';
+
+export type ScanTextResult = {
+  text: string;
+  // Contains the set of nodes and their ranges where text was found.
+  // This will be null if, for example, the result is the text from an element's
+  // title attribute.
+  textRange: TextRange;
+  // Extra metadata we parsed in the process
+  meta?: SelectionMeta;
+};
 
 export function scanText({
   startPosition,
@@ -12,7 +26,7 @@ export function scanText({
   startPosition: CursorPosition<Text>;
   matchCurrency: boolean;
   maxLength?: number;
-}): GetTextAtPointResult | null {
+}): ScanTextResult | null {
   const { offsetNode: startNode, offset: startOffset } = startPosition;
 
   // Get the ancestor for all inline nodes we intend to traverse
@@ -100,7 +114,7 @@ export function scanText({
     return null;
   }
 
-  const result: GetTextAtPointResult = { text: '', textRange: [] };
+  const result: ScanTextResult = { text: '', textRange: [] };
 
   let textDelimiter = nonJapaneseChar;
 


### PR DESCRIPTION
- chore: rename lastMouseMove... to lastPointerMove...
- fix: catch pointermove events in the capture phase
- chore: use the actual start element when looking up target properties
