### PR TITLE
Revert changes from #1773

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ app.
 - Added references for
   [The Kodansha Kanji Dictionary](https://www.kanji.org/dictionaries/KKD/kaneirev.htm).
 - Improved scanning of ruby transcription text.
+- Revert changes from [PR #1773](https://github.com/birchill/10ten-ja-reader/pull/1773). Puck can hold popup open again ([#2564](https://github.com/birchill/10ten-ja-reader/pull/2564)).
 
 ## [1.25.1] - 2025-07-22
 

--- a/src/content/puck.ts
+++ b/src/content/puck.ts
@@ -12,7 +12,6 @@ import {
   removeContentContainer,
 } from './content-container';
 import { getIframeOrigin } from './iframes';
-import { isPopupWindowHostElem } from './popup/popup-container';
 import type { SafeAreaProvider } from './safe-area-provider';
 
 interface ViewportDimensions {
@@ -432,12 +431,7 @@ export class LookupPuck {
       viewportOffsetTop;
 
     // See what we are pointing at
-    let target =
-      document
-        .elementsFromPoint(targetX, targetY)
-        // Ignore any element in the 10ten popup itself; we don't want
-        // the puck moon to hold the popup open like a mouse event does.
-        .find((target) => !isPopupWindowHostElem(target)) || null;
+    let target = document.elementFromPoint(targetX, targetY);
 
     // Check if we need to adjust the content to look it up.
     //


### PR DESCRIPTION
The original change in #1773 was well-intentioned but has wound up being really annoying. The situation where the puck covers part of the popup, and then you can't move it out of the way without it making the popup disappear, happens too frequently, and is worse than the original behavior it was trying to solve.

There is more that could be done to try to address the original issue in the future, but I'm of the opinion it should be reverted for now.