### PR TITLE
fix: workaround subsitution broken-ness in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ app.
   (see [#2674](https://github.com/birchill/10ten-ja-reader/pull/2674)).
 - Added support for Daikanwajiten (Morohashi) references
   ([#2734](https://github.com/birchill/10ten-ja-reader/pull/2734)).
+- Worked around a [major string substitution bug in Safari](https://bugs.webkit.org/show_bug.cgi?id=306492).
 
 ## [1.26.1] - 2025-12-23
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,11 +12,11 @@
     "description": "Tooltip for toolbar button when disabled."
   },
   "command_toggle_downloading": {
-    "message": "Downloading $datatype$ (​$progress$​%)…",
+    "message": "Downloading $datatype$  $progress$…",
     "description": "Tooltip for toolbar button when downloading updates.",
     "placeholders": {
       "datatype": { "content": "$1", "example": "radical data" },
-      "progress": { "content": "$2", "example": "12" }
+      "progress": { "content": "$2", "example": "(12%)" }
     }
   },
   "command_toggle_enabled": {
@@ -101,11 +101,11 @@
     "description": "Message shown when we fail to calculate the corresponding Gregorian date of a pre-Gregorian era"
   },
   "content_kanji_base_radical": {
-    "message": "from $char$ (​$readings$​)",
+    "message": "from $char$  $readings$",
     "description": "The string used to describe the base radical",
     "placeholders": {
       "char": { "content": "$1", "example": "⾡" },
-      "readings": { "content": "$2", "example": "しんにょう、しんにゅう" }
+      "readings": { "content": "$2", "example": "(しんにょう、しんにゅう)" }
     }
   },
   "content_kanji_components_label": {
@@ -134,7 +134,7 @@
     "placeholders": { "level": { "content": "$1", "example": "3" } }
   },
   "content_kanji_kentei_level_pre": {
-    "message": "Pre-​$level$",
+    "message": "Pre $level$",
     "placeholders": { "level": { "content": "$1", "example": "2" } }
   },
   "content_kanji_meta_ghost_kanji": {
@@ -328,7 +328,7 @@
     "placeholders": { "command": { "content": "$1", "example": "Ctrl+T " } }
   },
   "error_command_disallowed_modifier_key": {
-    "message": "Modifier '​$modifier$​' is not allowed",
+    "message": "Modifier ' $modifier$ ' is not allowed",
     "placeholders": { "modifier": { "content": "$1", "example": "Meta" } }
   },
   "error_command_has_no_key": { "message": "Must specify a key" },
@@ -336,7 +336,7 @@
     "message": "A modifier must be specified unless using a function key"
   },
   "error_command_key_is_not_allowed": {
-    "message": "Key '​$key$​' is not allowed",
+    "message": "Key ' $key$ ' is not allowed",
     "placeholders": { "key": { "content": "$1", "example": "Enter" } }
   },
   "error_command_media_key_with_modifier_key": {
@@ -1416,14 +1416,14 @@
     "description": "Label for the special item to disable currency conversion"
   },
   "options_data_series_date_only": {
-    "message": "Based on $source$ from $generated$​.",
+    "message": "Based on $source$ from $generated$.",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "generated": { "content": "$2", "example": "2019-10-19" }
     }
   },
   "options_data_series_version_and_date": {
-    "message": "Based on $source$ ​$version$ from $generated$​.",
+    "message": "Based on $source$  $version$ from $generated$.",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "version": { "content": "$2", "example": "2019-282" },
@@ -1477,12 +1477,12 @@
     "description": "Label for button to disable the toggle shortcut"
   },
   "options_downloading_data": {
-    "message": "Downloading $datatype$ version $version$ (​$progress$​%)…",
+    "message": "Downloading $datatype$ version $version$  $progress$…",
     "description": "Label while we are downloading updates",
     "placeholders": {
       "datatype": { "content": "$1", "example": "kanji data" },
       "version": { "content": "$2", "example": "1.0.3" },
-      "progress": { "content": "$3", "example": "60" }
+      "progress": { "content": "$3", "example": "(60%)" }
     }
   },
   "options_edrdg_license": {
@@ -1570,9 +1570,9 @@
     "description": "The name for the kanji database data set"
   },
   "options_kanji_data_title": {
-    "message": "Kanji data v​$version$",
+    "message": "Kanji data $version$",
     "description": "The kanji data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_kanji_dictionary_heading": {
     "message": "Kanji dictionary",
@@ -1636,9 +1636,9 @@
     "description": "The name for the name database data set"
   },
   "options_name_data_title": {
-    "message": "Name data v​$version$",
+    "message": "Name data $version$",
     "description": "The name data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_new_badge_text": {
     "message": "New!",
@@ -1818,19 +1818,19 @@
     "description": "The name for the words database data set"
   },
   "options_words_data_title": {
-    "message": "Word data v​$version$",
+    "message": "Word data $version$",
     "description": "The word data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "popup_bp_grammar_tag": {
-    "message": "BP N​$level$​ Grammar",
+    "message": "BP $level$ Grammar",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_bp_vocab_tag": {
-    "message": "BP N​$level$​ Vocab",
+    "message": "BP $level$ Vocab",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_close_label": {
     "message": "Close",
@@ -2268,7 +2268,7 @@
     }
   },
   "shogi_move_piece_dest_movement": {
-    "message": "$piece$ $movement$ $dest$",
+    "message": "$piece$  $movement$  $dest$",
     "placeholders": {
       "piece": { "content": "$1" },
       "dest": { "content": "$2" },
@@ -2276,7 +2276,7 @@
     }
   },
   "shogi_move_side_piece_dest": {
-    "message": "$side$ $piece$ to $dest$",
+    "message": "$side$  $piece$ to $dest$",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },
@@ -2284,7 +2284,7 @@
     }
   },
   "shogi_move_side_piece_dest_movement": {
-    "message": "$side$ $piece$ $movement$ $dest$",
+    "message": "$side$  $piece$  $movement$  $dest$",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -12,11 +12,11 @@
     "description": "Tooltip for toolbar button when disabled."
   },
   "command_toggle_downloading": {
-    "message": "$datatype$​を読み込み中 (​$progress$​%)…",
+    "message": "$datatype$を読み込み中 $progress$…",
     "description": "Tooltip for toolbar button when downloading updates.",
     "placeholders": {
       "datatype": { "content": "$1", "example": "radical data" },
-      "progress": { "content": "$2", "example": "12" }
+      "progress": { "content": "$2", "example": "(12%)" }
     }
   },
   "command_toggle_enabled": {
@@ -80,7 +80,7 @@
     "description": "Title shown at the top of the copy overlay when we can't find the word to copy."
   },
   "content_copy_overlay_copy_title_with_word": {
-    "message": "「​$word$​」をコピー",
+    "message": "「 $word$ 」をコピー",
     "description": "Title shown at the top of the copy overlay. It includes the matching headwords / kanji",
     "placeholders": { "word": { "content": "$1", "example": "選ぶ" } }
   },
@@ -101,11 +101,11 @@
     "description": "Message shown when we fail to calculate the corresponding Gregorian date of a pre-Gregorian era"
   },
   "content_kanji_base_radical": {
-    "message": "部 $char$ (​$readings$​)",
+    "message": "部 $char$  $readings$",
     "description": "The string used to describe the base radical",
     "placeholders": {
       "char": { "content": "$1", "example": "⾡" },
-      "readings": { "content": "$2", "example": "しんにょう、しんにゅう" }
+      "readings": { "content": "$2", "example": "(しんにょう、しんにゅう)" }
     }
   },
   "content_kanji_components_label": {
@@ -121,7 +121,7 @@
     "description": "Label for kanji marked as general use"
   },
   "content_kanji_grade_label": {
-    "message": "$grade$​年生",
+    "message": "$grade$年生",
     "description": "The label for kanji in grades 1 - 6",
     "placeholders": { "grade": { "content": "$1", "example": "3" } }
   },
@@ -130,11 +130,11 @@
     "description": "Label for kanji marked as name use"
   },
   "content_kanji_kentei_level": {
-    "message": "$level$​級",
+    "message": "$level$級",
     "placeholders": { "level": { "content": "$1", "example": "3" } }
   },
   "content_kanji_kentei_level_pre": {
-    "message": "準​$level$​級",
+    "message": "準 $level$級",
     "placeholders": { "level": { "content": "$1", "example": "2" } }
   },
   "content_kanji_meta_ghost_kanji": {
@@ -197,7 +197,7 @@
   "content_names_tag_unclass": { "message": "人名" },
   "content_names_tag_work": { "message": "作品" },
   "content_sk_match_src": {
-    "message": "「​$src$​」から",
+    "message": "「 $src$ 」から",
     "description": "The text used to show the sK/sk (search only) text that was used to look up the entry",
     "placeholders": { "src": { "content": "$1", "example": "御久しぶり" } }
   },
@@ -210,12 +210,12 @@
     "description": "Tooltip to show when hovering over the stop button for the stroke animation"
   },
   "content_wk_link_title": {
-    "message": "WaniKaniで「​$content$​」のページを表示",
+    "message": "WaniKaniで「 $content$ 」のページを表示",
     "description": "Tooltip for kanji and vocab links to WaniKani pages.",
     "placeholders": { "content": { "content": "$1", "example": "光" } }
   },
   "currency_data_updated_label": {
-    "message": "$updated$​に更新済み",
+    "message": "$updated$に更新済み",
     "description": "Caption added to popup explaining when the currency data was last refreshed",
     "placeholders": {
       "updated": { "content": "$1", "example": "Sep 16, 2021, 10:03 AM" }
@@ -320,11 +320,11 @@
     "description": "Tooltip label used when user hovers over the unfilled star icon (☆) to indicate a somewhat frequent word"
   },
   "error_command_could_not_parse": {
-    "message": "「​$command$​」の構文解析が失敗しました",
+    "message": "「 $command$ 」の構文解析が失敗しました",
     "placeholders": { "command": { "content": "$1", "example": "Ctrl+T " } }
   },
   "error_command_disallowed_modifier_key": {
-    "message": "「​$modifier$​」という修飾キーは利用できません",
+    "message": "「 $modifier$ 」という修飾キーは利用できません",
     "placeholders": { "modifier": { "content": "$1", "example": "Meta" } }
   },
   "error_command_has_no_key": { "message": "キーを設定してください" },
@@ -332,7 +332,7 @@
     "message": "機能キーまたメディアキーの利用以外の場合、修飾キーも設定してください"
   },
   "error_command_key_is_not_allowed": {
-    "message": "「​$key$​」というキーは利用できません",
+    "message": "「 $key$ 」というキーは利用できません",
     "placeholders": { "key": { "content": "$1", "example": "Enter" } }
   },
   "error_command_media_key_with_modifier_key": {
@@ -1078,7 +1078,7 @@
     "description": "The end of the text used to indicate a source language"
   },
   "lang_lsrc_wasei": {
-    "message": "和製​$lang$",
+    "message": "和製 $lang$",
     "placeholders": { "lang": { "content": "$1", "example": "英語" } }
   },
   "lang_lsrc_wasei_prefix": {
@@ -1414,14 +1414,14 @@
     "description": "Label for the special item to disable currency conversion"
   },
   "options_data_series_date_only": {
-    "message": "$generated$​に生成された​$source$​のデータに基づいている。",
+    "message": "$generated$に生成された $source$ のデータに基づいている。",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "generated": { "content": "$2", "example": "2019-10-19" }
     }
   },
   "options_data_series_version_and_date": {
-    "message": "$generated$​に生成された​$source$ $version$​のデータに基づいている。",
+    "message": "$generated$に生成された $source$  $version$ のデータに基づいている。",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "version": { "content": "$2", "example": "2019-282" },
@@ -1445,14 +1445,14 @@
     "description": "Label when IndexedDB is unusable with Firefox-specific help."
   },
   "options_db_update_error": {
-    "message": "更新失敗しました。「​$errormessage$​」",
+    "message": "更新失敗しました。「 $errormessage$ 」",
     "description": "Label when we failed to update the data for some reason",
     "placeholders": {
       "errormessage": { "content": "$1", "example": "Version file not found" }
     }
   },
   "options_db_update_next_retry": {
-    "message": "$nextretry$​に再試行予定",
+    "message": "$nextretry$に再試行予定",
     "description": "Label used when there is a scheduled retry",
     "placeholders": {
       "nextretry": { "content": "$1", "example": "2019-10-14 17:44" }
@@ -1475,12 +1475,12 @@
     "description": "Label for button to disable the toggle shortcut"
   },
   "options_downloading_data": {
-    "message": "$datatype$​バージョン​$version$​を読み込み中 (​$progress$​%)…",
+    "message": "$datatype$バージョン $version$ を読み込み中 $progress$…",
     "description": "Label while we are downloading updates",
     "placeholders": {
       "datatype": { "content": "$1", "example": "kanji data" },
       "version": { "content": "$2", "example": "1.0.3" },
-      "progress": { "content": "$3", "example": "60" }
+      "progress": { "content": "$3", "example": "(60%)" }
     }
   },
   "options_edrdg_license": {
@@ -1570,9 +1570,9 @@
     "description": "The name for the kanji database data set"
   },
   "options_kanji_data_title": {
-    "message": "漢字データ v​$version$",
+    "message": "漢字データ $version$",
     "description": "The kanji data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_kanji_dictionary_heading": {
     "message": "漢字辞典",
@@ -1636,9 +1636,9 @@
     "description": "The name for the name database data set"
   },
   "options_name_data_title": {
-    "message": "人名データ v​$version$",
+    "message": "人名データ $version$",
     "description": "The name data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_new_badge_text": {
     "message": "新機能！",
@@ -1822,19 +1822,19 @@
     "description": "The name for the words database data set"
   },
   "options_words_data_title": {
-    "message": "単語データ v​$version$",
+    "message": "単語データ $version$",
     "description": "The word data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "popup_bp_grammar_tag": {
-    "message": "BP N​$level$​ 文法",
+    "message": "BP $level$ 文法",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_bp_vocab_tag": {
-    "message": "BP N​$level$​ 単語",
+    "message": "BP $level$ 単語",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_close_label": {
     "message": "閉じる",
@@ -2253,7 +2253,7 @@
     "description": "The label used when presenting the Unicode codepoint of the kanji"
   },
   "ref_moro_format": {
-    "message": "$index$​（第⁠$volume$⁠巻 $page$⁠頁）",
+    "message": "$index$ （ $volume$巻  $page$頁 ）",
     "description": "Formatted Daikanwajiten (Morohashi) reference with volume and page numbers",
     "placeholders": {
       "index": { "content": "$1", "example": "12A" },
@@ -2265,14 +2265,14 @@
   "shogi_dest_same_suffix": { "message": "（同じ場所）" },
   "shogi_label": { "message": "将棋" },
   "shogi_move_piece_dest": {
-    "message": "$piece$​を​$dest$​に",
+    "message": "$piece$を $dest$に",
     "placeholders": {
       "piece": { "content": "$1" },
       "dest": { "content": "$2" }
     }
   },
   "shogi_move_piece_dest_movement": {
-    "message": "$piece$​を​$dest$​に​$movement$",
+    "message": "$piece$を $dest$に $movement$",
     "placeholders": {
       "piece": { "content": "$1" },
       "dest": { "content": "$2" },
@@ -2280,7 +2280,7 @@
     }
   },
   "shogi_move_side_piece_dest": {
-    "message": "$side$​が​$piece$​を​$dest$​に",
+    "message": "$side$が $piece$を $dest$に",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },
@@ -2288,7 +2288,7 @@
     }
   },
   "shogi_move_side_piece_dest_movement": {
-    "message": "$side$​が​$piece$​を​$dest$​に​$movement$",
+    "message": "$side$が $piece$を $dest$に $movement$",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -12,11 +12,11 @@
     "description": "Tooltip for toolbar button when disabled."
   },
   "command_toggle_downloading": {
-    "message": "正在下载​$datatype$​更新（​$progress$​%）……",
+    "message": "正在下载 $datatype$ 更新 $progress$…",
     "description": "Tooltip for toolbar button when downloading updates.",
     "placeholders": {
       "datatype": { "content": "$1", "example": "radical data" },
-      "progress": { "content": "$2", "example": "12" }
+      "progress": { "content": "$2", "example": "(12%)" }
     }
   },
   "command_toggle_enabled": {
@@ -76,11 +76,11 @@
     "description": "Label for the cancel button"
   },
   "content_copy_overlay_copy_title": {
-    "message": "复制​",
+    "message": "复制",
     "description": "Title shown at the top of the copy overlay when we can't find the word to copy."
   },
   "content_copy_overlay_copy_title_with_word": {
-    "message": "复制 '​$word$​'​",
+    "message": "复制 ' $word$ '",
     "description": "Title shown at the top of the copy overlay. It includes the matching headwords / kanji",
     "placeholders": { "word": { "content": "$1", "example": "選ぶ" } }
   },
@@ -101,11 +101,11 @@
     "description": "Message shown when we fail to calculate the corresponding Gregorian date of a pre-Gregorian era"
   },
   "content_kanji_base_radical": {
-    "message": "从​$char$​（​$readings$​）",
+    "message": "从 $char$  $readings$",
     "description": "The string used to describe the base radical",
     "placeholders": {
       "char": { "content": "$1", "example": "⾡" },
-      "readings": { "content": "$2", "example": "しんにょう、しんにゅう" }
+      "readings": { "content": "$2", "example": "(しんにょう、しんにゅう)" }
     }
   },
   "content_kanji_components_label": {
@@ -121,7 +121,7 @@
     "description": "Label for kanji marked as general use"
   },
   "content_kanji_grade_label": {
-    "message": "$grade$​级",
+    "message": "$grade$级",
     "description": "The label for kanji in grades 1 - 6",
     "placeholders": { "grade": { "content": "$1", "example": "3" } }
   },
@@ -130,11 +130,11 @@
     "description": "Label for kanji marked as name use"
   },
   "content_kanji_kentei_level": {
-    "message": "$level$​级",
+    "message": "$level$级",
     "placeholders": { "level": { "content": "$1", "example": "3" } }
   },
   "content_kanji_kentei_level_pre": {
-    "message": "准​$level$​级",
+    "message": "准 $level$级",
     "placeholders": { "level": { "content": "$1", "example": "2" } }
   },
   "content_kanji_meta_ghost_kanji": {
@@ -197,7 +197,7 @@
   "content_names_tag_unclass": { "message": "人物" },
   "content_names_tag_work": { "message": "作品" },
   "content_sk_match_src": {
-    "message": "来自 '​$src$​'",
+    "message": "来自 ' $src$ '",
     "description": "The text used to show the sK/sk (search only) text that was used to look up the entry",
     "placeholders": { "src": { "content": "$1", "example": "御久しぶり" } }
   },
@@ -210,7 +210,7 @@
     "description": "Tooltip to show when hovering over the stop button for the stroke animation"
   },
   "content_wk_link_title": {
-    "message": "显示 '​$content$​' 的WaniKani页面",
+    "message": "显示 ' $content$ ' 的WaniKani页面",
     "description": "Tooltip for kanji and vocab links to WaniKani pages.",
     "placeholders": { "content": { "content": "$1", "example": "光" } }
   },
@@ -324,7 +324,7 @@
     "placeholders": { "command": { "content": "$1", "example": "Ctrl+T " } }
   },
   "error_command_disallowed_modifier_key": {
-    "message": "修饰键 '​$modifier$​' 不能使用",
+    "message": "修饰键 ' $modifier$ ' 不能使用",
     "placeholders": { "modifier": { "content": "$1", "example": "Meta" } }
   },
   "error_command_has_no_key": { "message": "必须指定按键" },
@@ -332,7 +332,7 @@
     "message": "必须使用一个修饰键，除非使用功能键（F1-F12）。"
   },
   "error_command_key_is_not_allowed": {
-    "message": "按键 '​$key$​' 不可用",
+    "message": "按键 ' $key$ ' 不可用",
     "placeholders": { "key": { "content": "$1", "example": "Enter" } }
   },
   "error_command_media_key_with_modifier_key": {
@@ -1076,7 +1076,7 @@
     "description": "The end of the text used to indicate a source language"
   },
   "lang_lsrc_wasei": {
-    "message": "和制​$lang$",
+    "message": "和制 $lang$",
     "placeholders": { "lang": { "content": "$1", "example": "英语" } }
   },
   "lang_lsrc_wasei_prefix": {
@@ -1412,14 +1412,14 @@
     "description": "Label for the special item to disable currency conversion"
   },
   "options_data_series_date_only": {
-    "message": "基于 $source$ 资料，生成于 $generated$​。",
+    "message": "基于 $source$ 资料，生成于 $generated$。",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "generated": { "content": "$2", "example": "2019-10-19" }
     }
   },
   "options_data_series_version_and_date": {
-    "message": "基于 $source$ 版本 $version$​，生成于 $generated$​。",
+    "message": "基于 $source$ 版本 $version$ 生成于 $generated$。",
     "placeholders": {
       "source": { "content": "$1", "example": "KANJIDIC" },
       "version": { "content": "$2", "example": "2019-282" },
@@ -1443,7 +1443,7 @@
     "description": "Label when IndexedDB is unusable with Firefox-specific help."
   },
   "options_db_update_error": {
-    "message": "更新失败：​$errormessage$",
+    "message": "更新失败： $errormessage$",
     "description": "Label when we failed to update the data for some reason",
     "placeholders": {
       "errormessage": { "content": "$1", "example": "Version file not found" }
@@ -1473,12 +1473,12 @@
     "description": "Label for button to disable the toggle shortcut"
   },
   "options_downloading_data": {
-    "message": "正在下载​$datatype$​，版本 $version$​（​$progress$​%）……",
+    "message": "正在下载 $datatype$ 版本 $version$  $progress$…",
     "description": "Label while we are downloading updates",
     "placeholders": {
       "datatype": { "content": "$1", "example": "kanji data" },
       "version": { "content": "$2", "example": "1.0.3" },
-      "progress": { "content": "$3", "example": "60" }
+      "progress": { "content": "$3", "example": "(60%)" }
     }
   },
   "options_edrdg_license": {
@@ -1566,9 +1566,9 @@
     "description": "The name for the kanji database data set"
   },
   "options_kanji_data_title": {
-    "message": "汉字数据版本 v​$version$",
+    "message": "汉字数据版本 $version$",
     "description": "The kanji data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_kanji_dictionary_heading": {
     "message": "汉字词典",
@@ -1632,9 +1632,9 @@
     "description": "The name for the name database data set"
   },
   "options_name_data_title": {
-    "message": "名字数据版本 v​$version$",
+    "message": "名字数据版本 $version$",
     "description": "The name data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "options_new_badge_text": {
     "message": "新功能！",
@@ -1814,19 +1814,19 @@
     "description": "The name for the words database data set"
   },
   "options_words_data_title": {
-    "message": "单词数据版本 v​$version$",
+    "message": "单词数据版本 $version$",
     "description": "The word data series title and version",
-    "placeholders": { "version": { "content": "$1", "example": "2.0.0" } }
+    "placeholders": { "version": { "content": "$1", "example": "v2.0.0" } }
   },
   "popup_bp_grammar_tag": {
-    "message": "BP N​$level$​ 语法",
+    "message": "BP $level$ 语法",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_bp_vocab_tag": {
-    "message": "BP N​$level$​ 单词",
+    "message": "BP $level$ 单词",
     "description": "The tag shown alongside a headword that is part of a Bunpro vocab deck indicating what level deck it is from",
-    "placeholders": { "level": { "content": "$1", "example": "5" } }
+    "placeholders": { "level": { "content": "$1", "example": "N5" } }
   },
   "popup_close_label": {
     "message": "关闭",
@@ -2245,7 +2245,7 @@
     "description": "The label used when presenting the Unicode codepoint of the kanji"
   },
   "ref_moro_format": {
-    "message": "$index$​（第⁠$volume$⁠卷 第⁠$page$⁠页）",
+    "message": "$index$（第 $volume$卷 第 $page$页）",
     "description": "Formatted Daikanwajiten (Morohashi) reference with volume and page numbers",
     "placeholders": {
       "index": { "content": "$1", "example": "12A" },
@@ -2257,14 +2257,14 @@
   "shogi_dest_same_suffix": { "message": "（同じ場所）" },
   "shogi_label": { "message": "日本将棋" },
   "shogi_move_piece_dest": {
-    "message": "$piece$​を​$dest$​に",
+    "message": "$piece$を $dest$に",
     "placeholders": {
       "piece": { "content": "$1" },
       "dest": { "content": "$2" }
     }
   },
   "shogi_move_piece_dest_movement": {
-    "message": "$piece$​を​$dest$​に​$movement$",
+    "message": "$piece$を $dest$に $movement$",
     "placeholders": {
       "piece": { "content": "$1" },
       "dest": { "content": "$2" },
@@ -2272,7 +2272,7 @@
     }
   },
   "shogi_move_side_piece_dest": {
-    "message": "$side$​が​$piece$​を​$dest$​に",
+    "message": "$side$が $piece$を $dest$に",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },
@@ -2280,7 +2280,7 @@
     }
   },
   "shogi_move_side_piece_dest_movement": {
-    "message": "$side$​が​$piece$​を​$dest$​に​$movement$",
+    "message": "$side$が $piece$を $dest$に $movement$",
     "placeholders": {
       "side": { "content": "$1" },
       "piece": { "content": "$2" },

--- a/src/background/browser-action.ts
+++ b/src/background/browser-action.ts
@@ -151,7 +151,7 @@ async function doUpdateBrowserAction({
         const progressAsPercent = Math.round(totalProgress * 100);
         tooltip = browser.i18n.getMessage('command_toggle_downloading', [
           dbLabel,
-          String(progressAsPercent),
+          `(${progressAsPercent}%)`,
         ]);
       }
       break;

--- a/src/content/copy-text.test.ts
+++ b/src/content/copy-text.test.ts
@@ -7,9 +7,9 @@ import { getEntryToCopy, getFieldsToCopy, getWordToCopy } from './copy-text';
 const getMessage = (id: string, replacements?: string | Array<string>) => {
   switch (id) {
     case 'content_kanji_base_radical':
-      return `from ${replacements ? replacements[0] : '?'} (${
+      return `from ${replacements ? replacements[0] : '?'} ${
         replacements ? replacements[1] : '?'
-      })`;
+      }`;
     case 'content_kanji_components_label':
       return 'components';
     case 'content_kanji_radical_label':

--- a/src/content/popup/Kanji/KanjiComponents.tsx
+++ b/src/content/popup/Kanji/KanjiComponents.tsx
@@ -82,7 +82,10 @@ function BaseRadical(props: NonNullable<KanjiResult['comp'][0]['base']>) {
       lang={langTag}
       class="tp:col-start-2 tp:col-end-4 tp:-mt-1 tp:pl-2 tp:pr-3 tp:italic tp:text-(--cell-highlight-fg)"
     >
-      {t('content_kanji_base_radical', [props.c, props.na[0] || '-'])}
+      {t('content_kanji_base_radical', [
+        props.c,
+        props.na[0] ? `(${props.na[0]})` : '',
+      ])}
     </span>
   );
 }

--- a/src/content/popup/Words/WordEntry.tsx
+++ b/src/content/popup/Words/WordEntry.tsx
@@ -369,7 +369,7 @@ function BunproTag({
 
   const label = t(
     type === 'vocab' ? 'popup_bp_vocab_tag' : 'popup_bp_grammar_tag',
-    [String(data.l)]
+    ['N' + data.l]
   );
 
   return (

--- a/src/content/popup/metadata.test.ts
+++ b/src/content/popup/metadata.test.ts
@@ -34,10 +34,10 @@ describe('renderShogiInfo', () => {
       'silver general to 83'
     );
     expect(getShogiMove({ dest: [8, 3], piece: 's' }, 'ja')).toBe(
-      '銀将を８三に'
+      '銀将を ８三に'
     );
     expect(getShogiMove({ dest: [8, 3], piece: 's' }, 'zh_CN')).toBe(
-      '銀将を８三に'
+      '銀将を ８三に'
     );
   });
 
@@ -45,8 +45,8 @@ describe('renderShogiInfo', () => {
     expect(getShogiMove({ piece: 's' })).toBe(
       "silver general to previous move's position"
     );
-    expect(getShogiMove({ piece: 's' }, 'ja')).toBe('銀将を同じ場所に');
-    expect(getShogiMove({ piece: 's' }, 'zh_CN')).toBe('銀将を同じ場所に');
+    expect(getShogiMove({ piece: 's' }, 'ja')).toBe('銀将を 同じ場所に');
+    expect(getShogiMove({ piece: 's' }, 'zh_CN')).toBe('銀将を 同じ場所に');
   });
 
   it('renders a shogi move with a destination indicated as being the same', () => {
@@ -54,35 +54,35 @@ describe('renderShogiInfo', () => {
       'silver general to 83 (same as previous move)'
     );
     expect(getShogiMove({ dest: [8, 3, 1], piece: 's' }, 'ja')).toBe(
-      '銀将を８三（同じ場所）に'
+      '銀将を ８三（同じ場所）に'
     );
     expect(getShogiMove({ dest: [8, 3, 1], piece: 's' }, 'zh_CN')).toBe(
-      '銀将を８三（同じ場所）に'
+      '銀将を ８三（同じ場所）に'
     );
   });
 
   it('renders a shogi move where a side is specified', () => {
     expect(getShogiMove({ side: 'black', dest: [2, 5], piece: 'pro_b' })).toBe(
-      'black horse (promoted bishop) to 25'
+      'black  horse (promoted bishop) to 25'
     );
     expect(
       getShogiMove({ side: 'black', dest: [2, 5], piece: 'pro_b' }, 'ja')
-    ).toBe('先手が竜馬を２五に');
+    ).toBe('先手が 竜馬を ２五に');
     expect(
       getShogiMove({ side: 'black', dest: [2, 5], piece: 'pro_b' }, 'zh_CN')
-    ).toBe('先手が竜馬を２五に');
+    ).toBe('先手が 竜馬を ２五に');
   });
 
   it('renders a shogi move where a movement is specified', () => {
     expect(getShogiMove({ dest: [5, 2], piece: 'g', movement: 'right' })).toBe(
-      'gold general moves from the right to 52'
+      'gold general  moves from the right to  52'
     );
     expect(
       getShogiMove({ dest: [5, 2], piece: 'g', movement: 'right' }, 'ja')
-    ).toBe('金将を５二に右から動かす');
+    ).toBe('金将を ５二に 右から動かす');
     expect(
       getShogiMove({ dest: [5, 2], piece: 'g', movement: 'right' }, 'zh_CN')
-    ).toBe('金将を５二に右から動かす');
+    ).toBe('金将を ５二に 右から動かす');
   });
 
   it('renders a shogi move where a movement and side are specified', () => {
@@ -93,19 +93,19 @@ describe('renderShogiInfo', () => {
         piece: 'g',
         movement: 'drop',
       })
-    ).toBe('white gold general dropped at 56');
+    ).toBe('white  gold general  dropped at  56');
     expect(
       getShogiMove(
         { side: 'white', dest: [5, 6], piece: 'g', movement: 'drop' },
         'ja'
       )
-    ).toBe('後手が金将を５六に打つ');
+    ).toBe('後手が 金将を ５六に 打つ');
     expect(
       getShogiMove(
         { side: 'white', dest: [5, 6], piece: 'g', movement: 'drop' },
         'zh_CN'
       )
-    ).toBe('後手が金将を５六に打つ');
+    ).toBe('後手が 金将を ５六に 打つ');
   });
 
   it('renders a shogi move with promotion information', () => {
@@ -116,19 +116,19 @@ describe('renderShogiInfo', () => {
         piece: 's',
         promotion: false,
       })
-    ).toBe('black silver general to 44 without promoting');
+    ).toBe('black  silver general to 44 without promoting');
     expect(
       getShogiMove(
         { side: 'black', dest: [4, 4], piece: 's', promotion: false },
         'ja'
       )
-    ).toBe('先手が銀将を４四に（成らない）');
+    ).toBe('先手が 銀将を ４四に（成らない）');
     expect(
       getShogiMove(
         { side: 'black', dest: [4, 4], piece: 's', promotion: false },
         'zh_CN'
       )
-    ).toBe('先手が銀将を４四に（成らない）');
+    ).toBe('先手が 銀将を ４四に（成らない）');
   });
 });
 

--- a/src/options/DbStatus.tsx
+++ b/src/options/DbStatus.tsx
@@ -155,7 +155,7 @@ function DbSummaryStatus(props: {
           {t('options_downloading_data', [
             dbLabel,
             versionString,
-            String(progressAsPercent),
+            `(${progressAsPercent}%)`,
           ])}
         </label>
       </div>
@@ -225,7 +225,7 @@ function IdleStateSummary(props: {
 
   return (
     <DbSummaryContainer>
-      <div class="grid auto-cols-fr grid-flow-col grid-rows-[repeat(2,_auto)] gap-x-2 sm:gap-x-4">
+      <div class="grid auto-cols-fr grid-flow-col grid-rows-[repeat(2,auto)] gap-x-2 sm:gap-x-4">
         {allMajorDataSeries.map((series) => {
           const versionInfo = props.dbState[series].version;
           return versionInfo ? (
@@ -353,7 +353,7 @@ function DataSeriesVersion(props: {
   const { major, minor, patch, lang } = props.version;
   const titleString = t(
     titleKeys[props.series],
-    `${major}.${minor}.${patch} (${lang})`
+    `v${major}.${minor}.${patch} (${lang})`
   );
 
   const sourceNames: { [series in MajorDataSeries]: string } = {


### PR DESCRIPTION
See https://bugs.webkit.org/show_bug.cgi?id=306492

Our previous (U+200B) workaround no longer works. Safari is,
unsurprisingly, just completely broken.

So we'll need to add all sorts of unsightly spaces into our strings
on all platforms until Safari fixes their bug or we switch to using our
own userspace localization function.

Hopefully this commit serves as a single place where we added all the
workarounds so we can revert them at such a time.
