### PR TITLE
fix(options): prevent disconnected port object error on postMessage

### DIFF
--- a/src/options/use-db.ts
+++ b/src/options/use-db.ts
@@ -31,7 +31,6 @@ export function useDb(): {
 
   useEffect(() => {
     let browserPort = browser.runtime.connect(undefined, { name: 'options' });
-    browserPortRef.current = browserPort;
 
     const onMessage = (event: unknown) => {
       if (isDbStateUpdatedMessage(event)) {
@@ -95,13 +94,12 @@ export function useDb(): {
             return;
           }
           browserPort = browser.runtime.connect(undefined, { name: 'options' });
+          browserPort.onMessage.addListener(onMessage);
+          browserPort.onDisconnect.addListener(onDisconnect);
           browserPortRef.current = browserPort;
           Bugsnag.leaveBreadcrumb(
             'Options page reconnected to background page'
           );
-
-          browserPort.onMessage.addListener(onMessage);
-          browserPort.onDisconnect.addListener(onDisconnect);
         } catch (e) {
           void Bugsnag.notify(e);
         }
@@ -110,6 +108,7 @@ export function useDb(): {
 
     browserPort.onMessage.addListener(onMessage);
     browserPort.onDisconnect.addListener(onDisconnect);
+    browserPortRef.current = browserPort;
 
     window.addEventListener('unload', () => {
       browserPort?.disconnect();
@@ -123,15 +122,27 @@ export function useDb(): {
   }, []);
 
   const startDatabaseUpdate = useCallback(() => {
-    browserPortRef.current?.postMessage(updateDb());
+    try {
+      browserPortRef.current?.postMessage(updateDb());
+    } catch {
+      browserPortRef.current = undefined;
+    }
   }, []);
 
   const cancelDatabaseUpdate = useCallback(() => {
-    browserPortRef.current?.postMessage(cancelDbUpdate());
+    try {
+      browserPortRef.current?.postMessage(cancelDbUpdate());
+    } catch {
+      browserPortRef.current = undefined;
+    }
   }, []);
 
   const deleteDatabase = useCallback(() => {
-    browserPortRef.current?.postMessage(deleteDb());
+    try {
+      browserPortRef.current?.postMessage(deleteDb());
+    } catch {
+      browserPortRef.current = undefined;
+    }
   }, []);
 
   return { dbState, startDatabaseUpdate, cancelDatabaseUpdate, deleteDatabase };


### PR DESCRIPTION
In the options page, `browserPortRef.current` could end up holding a
reference to a disconnected `Runtime.Port`, causing an unhandled
"Attempting to use a disconnected port object" error whenever the user
triggered a DB action (e.g. "Check for updates") via the port.

The root cause is an ordering issue in the reconnect path inside
`onDisconnect`'s setTimeout callback (and, for consistency, the initial
connection setup). `browserPortRef.current` was assigned immediately
after `browser.runtime.connect()` returned, before the `onDisconnect`
listener was registered on the new port. If Chrome MV3 fires the
`onDisconnect` callback synchronously (which it can do when the service
worker is sleeping and the new port is immediately dead), the handler
would clear `browserPortRef.current` to `undefined` — only for the
assignment on the next line to set it back to the disconnected port.
The `onDisconnect` listener for that port would never fire again, so
the stale reference was never cleaned up.

Fix:
- Register `onMessage` and `onDisconnect` listeners on the new port
  before assigning it to `browserPortRef.current`, in both the initial
  connection and reconnect paths. This ensures that if `onDisconnect`
  fires synchronously the ref stays `undefined` rather than being
  overwritten with the dead port.
- Wrap all three `postMessage` call sites in try/catch as a defensive
  guard: if a stale port reference somehow survives despite the
  structural fix, the error is caught and the ref is cleared rather
  than surfacing as an unhandled exception.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
