### PR TITLE
fix: restore Google Docs bullet text lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ app.
 
 ## [Unreleased]
 
+- Fixed the popup not appearing for bullet-list text in Google Docs
+  ([#2926](https://github.com/birchill/10ten-ja-reader/issues/2926)).
+
 ## [1.27.1] - 2026-05-06 (Firefox, Thunderbird only)
 
 - (Firefox, Thunderbird) Fixed generation of source artifacts.

--- a/src/content/scan-text.browser.test.ts
+++ b/src/content/scan-text.browser.test.ts
@@ -1,0 +1,53 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { scanText as scanTextFn } from './scan-text';
+
+declare global {
+  var browser: any;
+  var chrome: any;
+}
+
+describe('scanText', () => {
+  let previousChromeObject: any;
+  let previousBrowserObject: any;
+
+  let scanText: typeof scanTextFn;
+
+  beforeAll(async () => {
+    // Make sure the webextension polyfill believes we are in an extension
+    // context.
+    previousChromeObject = globalThis.chrome;
+    globalThis.chrome = { runtime: { id: 'test' } };
+
+    // Polyfill any browser APIs we use.
+    previousBrowserObject = globalThis.browser;
+    globalThis.browser = {
+      // <-- Put polyfills for any browser APIs we use in here
+    };
+
+    ({ scanText } = await import('./scan-text'));
+  });
+
+  afterAll(() => {
+    globalThis.browser = previousBrowserObject;
+    globalThis.chrome = previousChromeObject;
+  });
+
+  describe('synthetic text nodes', () => {
+    it('scans detached Google Docs text with bullet prelude context', () => {
+      const scanNode = document.createTextNode('テスト');
+      const container = document.createElement('span');
+      container.append(document.createTextNode('●'), scanNode);
+
+      const result = scanText({
+        startPosition: { offsetNode: scanNode, offset: 0 },
+        matchCurrency: true,
+      });
+
+      expect(result).toMatchObject({
+        text: 'テスト',
+        textRange: [{ node: scanNode, start: 0, end: 3 }],
+      });
+    });
+  });
+});

--- a/src/content/scan-text.ts
+++ b/src/content/scan-text.ts
@@ -86,10 +86,6 @@ export function scanText({
   let includeNodeText: (node: Node) => node is Text;
   if (rtLevel > 0) {
     includeNodeText = (node): node is Text => {
-      if (node.nodeType !== Node.TEXT_NODE) {
-        return false;
-      }
-
       if (!isVisibleTextNode(node)) {
         return false;
       }
@@ -102,9 +98,7 @@ export function scanText({
     };
   } else {
     includeNodeText = (node): node is Text =>
-      node.nodeType === Node.TEXT_NODE &&
-      isVisibleTextNode(node) &&
-      !node.parentElement?.closest('rp, rt');
+      isVisibleTextNode(node) && !node.parentElement?.closest('rp, rt');
   }
 
   // Setup a node iterator starting at the current node
@@ -417,12 +411,16 @@ function isEffectiveInline(element: Element | null): element is Element {
   );
 }
 
-function isVisibleTextNode(node: Text): boolean {
+function isVisibleTextNode(node: Node): node is Text {
   const parent = node.parentElement;
   return (
-    !parent ||
-    !parent.isConnected ||
-    parent.checkVisibility({ opacityProperty: true, visibilityProperty: true })
+    node.nodeType === Node.TEXT_NODE &&
+    (!parent ||
+      !parent.isConnected ||
+      parent.checkVisibility({
+        opacityProperty: true,
+        visibilityProperty: true,
+      }))
   );
 }
 
@@ -533,8 +531,7 @@ class SourceContextBuilder {
       return;
     }
 
-    const textNode = node as Text;
-    if (!isVisibleTextNode(textNode)) {
+    if (!isVisibleTextNode(node)) {
       return;
     }
 
@@ -544,18 +541,18 @@ class SourceContextBuilder {
     if (!rubyElement) {
       this.flush();
       this.#target.push(
-        normalizeSourceContextText(textNode.data.substring(offset))
+        normalizeSourceContextText(node.data.substring(offset))
       );
       return;
     }
 
     // Case 2: Inside an <rp> element - ignore
-    if (textNode.parentElement?.closest('rp')) {
+    if (node.parentElement?.closest('rp')) {
       return;
     }
 
     const nodeRtLevel = getRtLevel(node);
-    const textContent = normalizeSourceContextText(textNode.data);
+    const textContent = normalizeSourceContextText(node.data);
 
     // Case 3: Inside ruby base text
     if (nodeRtLevel === 0) {

--- a/src/content/scan-text.ts
+++ b/src/content/scan-text.ts
@@ -90,12 +90,7 @@ export function scanText({
         return false;
       }
 
-      if (
-        !node.parentElement?.checkVisibility({
-          opacityProperty: true,
-          visibilityProperty: true,
-        })
-      ) {
+      if (!isVisibleTextNode(node)) {
         return false;
       }
 
@@ -108,10 +103,7 @@ export function scanText({
   } else {
     includeNodeText = (node): node is Text =>
       node.nodeType === Node.TEXT_NODE &&
-      node.parentElement?.checkVisibility({
-        opacityProperty: true,
-        visibilityProperty: true,
-      }) !== false &&
+      isVisibleTextNode(node) &&
       !node.parentElement?.closest('rp, rt');
   }
 
@@ -425,6 +417,15 @@ function isEffectiveInline(element: Element | null): element is Element {
   );
 }
 
+function isVisibleTextNode(node: Text): boolean {
+  const parent = node.parentElement;
+  return (
+    !parent ||
+    !parent.isConnected ||
+    parent.checkVisibility({ opacityProperty: true, visibilityProperty: true })
+  );
+}
+
 // ----------------------------------------------------------------------------
 //
 // Ruby helpers
@@ -532,16 +533,11 @@ class SourceContextBuilder {
       return;
     }
 
-    if (
-      node.parentElement?.checkVisibility({
-        opacityProperty: true,
-        visibilityProperty: true,
-      }) === false
-    ) {
+    const textNode = node as Text;
+    if (!isVisibleTextNode(textNode)) {
       return;
     }
 
-    const textNode = node as Text;
     const rubyElement = getOutermostRuby(node);
 
     // Case 1: Not inside a ruby


### PR DESCRIPTION
Google Docs canvas lookups synthesize detached text nodes so scanText
can use generated context. Bullet list text includes a detached span
parent for the bullet prelude, and checkVisibility() returns false for
that detached element, causing the popup lookup to return null.

Treat detached synthetic text parents as visible while preserving
checkVisibility() filtering for connected DOM nodes.

Fixes #2926.
