### PR TITLE
chore: show the changelog in the changeset release PR body

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - data/words.ljson
       - data/words.idx
+      - CHANGELOG.md
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - data/words.ljson
       - data/words.idx
+      - CHANGELOG.md
   pull_request:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
       - data/words.ljson
       - data/words.idx
+      - CHANGELOG.md
   workflow_dispatch:
 
 jobs:
@@ -78,17 +79,20 @@ jobs:
         if: ${{ steps.out.outputs.should_release == 'true' }}
         run: pnpm update-snapshot
 
-      - name: Commit and push updated word snapshot
+      - name: Stamp changelog release date
+        if: ${{ steps.out.outputs.should_release == 'true' }}
+        run: pnpm stamp-changelog-date
+
+      - name: Commit and push release preparation
         if: ${{ steps.out.outputs.should_release == 'true' }}
         run: |-
-          git add data/words.ljson data/words.idx
+          git add data/words.ljson data/words.idx CHANGELOG.md
           if git diff --cached --quiet; then
-            echo "Word snapshot is already up to date."
+            echo "Nothing to update for release preparation."
             exit 0
           fi
 
-          timestamp=$(date -u)
-          git commit -m "chore: Update word snapshot (${timestamp})"
+          git commit -m "chore: prepare release v${{ steps.out.outputs.version }}"
           git push
 
       - name: Set release ref

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,17 @@ start the item with the existing target annotation style, e.g. `(Firefox)` or
 `(Chrome, Edge)`. Bare issue references such as `#123` are linked when
 Changesets updates the changelog.
 
+These target annotations also decide which stores a release is published to. An
+unannotated note applies to every browser, so a browser is only skipped if
+_every_ note in the release excludes it. To cut a Firefox-only release, for
+example, annotate every note with `(Firefox)`; the other stores then have no
+applicable notes and are skipped automatically, and the changelog heading is
+stamped with a matching `(Firefox only)` annotation for the historical record.
+
+(Note that the Safari/iOS build is always uploaded to App Store Connect
+regardless of these annotations—uploading a build there does not oblige us to
+actually submit it for release—and Thunderbird is published manually.)
+
 Pre-release checks:
 
 - If we've made changes to the build setup at all, it's good to run
@@ -245,11 +256,16 @@ creates or updates a release PR. That PR contains the computed version bump,
 the generated changelog, synced manifest/Xcode marketing versions, and a preview
 comment showing both the GitHub release notes and the store-submission notes.
 
-Merge the release PR when you are ready to release. The
+Until release, the new version's changelog heading stays in its plain
+`## <version>` form (this is what lets the Changesets action show just the new
+section in the release PR body). Merge the release PR when you are ready to
+release. The
 [Release workflow](https://github.com/birchill/10ten-ja-reader/actions/workflows/release.yml)
-then updates the dictionary snapshot, builds the release assets from that
-updated commit, tags it, and creates a draft GitHub release that you need to
-publish before anything gets uploaded.
+then updates the dictionary snapshot, stamps the release date (and, for a
+browser-restricted release, a `(… only)` annotation) onto the changelog heading
+(`## [<version>] - <date>`), builds the release assets from that updated commit,
+tags it, and creates a draft GitHub release that you need to publish before
+anything gets uploaded.
 
 If you need to test the versioning process locally, use a temporary branch and
 run:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "package:thunderbird": "rspack --env target=thunderbird --env package",
     "postprocess-changeset-changelog": "node scripts/postprocess-changeset-changelog.js",
     "sort-i18n-keys": "tsx scripts/sort-keys",
+    "stamp-changelog-date": "node scripts/stamp-changelog-release-date.js",
     "start:chrome": "rspack -w --env target=chrome",
     "start:edge": "rspack -w --env target=chrome --env chromium=edge",
     "start:firefox": "rspack -w",

--- a/scripts/postprocess-changeset-changelog.js
+++ b/scripts/postprocess-changeset-changelog.js
@@ -2,9 +2,15 @@ import * as fs from 'node:fs';
 import * as url from 'node:url';
 
 // Normalizes the CHANGELOG.md output from `changeset version` to match this
-// repo's existing changelog format: add the release date to the generated
-// version heading, remove Changesets' change-type section headings, and keep
-// the new release block directly after the Unreleased section.
+// repo's existing changelog format: remove Changesets' change-type section
+// headings, and keep the new release block directly after the Unreleased
+// section.
+//
+// The version heading is deliberately left in its plain `## <version>` form so
+// that the Changesets action can locate the new release's section when building
+// the release PR body (it matches a heading whose text is exactly the version).
+// The Keep a Changelog date is stamped onto the heading later, at release time,
+// by `scripts/stamp-changelog-release-date.js`.
 
 const CHANGESET_SECTION_HEADINGS = new Set([
   '### Major Changes',
@@ -26,12 +32,7 @@ function main() {
     new URL('../CHANGELOG.md', import.meta.url)
   );
   const original = fs.readFileSync(changeLogPath, 'utf8');
-  const date = new Date().toISOString().slice(0, 10);
   const lines = original
-    .replace(
-      new RegExp(`^## ${escapeRegExp(version)}$`, 'm'),
-      `## [${version}] - ${date}`
-    )
     .split(/\r\n|\r|\n/g)
     .filter((line) => !CHANGESET_SECTION_HEADINGS.has(line));
   const updated = `${moveReleaseBlockAfterUnreleased({ lines, version })
@@ -111,9 +112,9 @@ function trimReleaseBlockEnd({ lines, releaseStart, releaseEnd }) {
 }
 
 function isVersionHeading({ line, version }) {
-  return new RegExp(
-    `^## \\[${escapeRegExp(version)}\\] - \\d{4}-\\d{2}-\\d{2}`
-  ).test(line);
+  // `changeset version` emits a plain `## <version>` heading; the date is added
+  // later at release time.
+  return new RegExp(`^## ${escapeRegExp(version)}\\s*$`).test(line);
 }
 
 function isUnreleasedHeading(line) {

--- a/scripts/release-notes/format-release-notes.js
+++ b/scripts/release-notes/format-release-notes.js
@@ -5,22 +5,42 @@
  * @returns {string}
  */
 export function formatReleaseNotes({ changeLog, version }) {
+  const notes = extractVersionNotes({ changeLog, version });
+  const humanNotes = toHumanNotes(notes);
+
+  // Generate specific notes for each browser
+  return `${notes}\n\n<!--\n${getBrowserNotes({ notes: humanNotes })}\n-->`;
+}
+
+/**
+ * Returns the list of browsers that have at least one applicable note in the
+ * given version's release notes, in canonical order.
+ *
+ * A note with no browser annotation applies to every browser, so this returns
+ * the full set unless _every_ note is annotated to exclude some browser. This
+ * is what determines which stores a release is published to (a browser with no
+ * notes gets no section in the release notes, so its publish step is skipped).
+ *
+ * @param {{ changeLog: string; version: string }} options
+ * @returns {Array<string>}
+ */
+export function getReleaseTargets({ changeLog, version }) {
+  const humanNotes = toHumanNotes(extractVersionNotes({ changeLog, version }));
+  return browsers.filter(
+    (browser) => getNotesForBrowser({ notes: humanNotes, browser }) !== null
+  );
+}
+
+export const browsers = ['Firefox', 'Chrome', 'Edge', 'Safari', 'Thunderbird'];
+
+// Extracts the raw markdown body for the given version, with line-wrapped
+// bullet points merged onto a single line.
+function extractVersionNotes({ changeLog, version }) {
   // Get the lines of the changelog for the specified version
   const lines = changeLog.split(/\r\n|\r|\n/g);
-  const start = lines.findIndex((line) => getVersionHeading({ line, version }));
+  const start = lines.findIndex((line) => isVersionHeading({ line, version }));
   if (start === -1) {
     throw new Error(`Could not find release notes for version ${version}`);
-  }
-
-  // Parse out any annotation on the version number restricting the set of
-  // included browsers.
-  const versionAnnotation = getVersionHeading({
-    line: lines[start],
-    version,
-  })?.annotation;
-  let supportedBrowsers = null;
-  if (versionAnnotation) {
-    supportedBrowsers = getSupportedBrowsers(versionAnnotation);
   }
 
   // Look for the next version or the references section at the end
@@ -47,7 +67,12 @@ export function formatReleaseNotes({ changeLog, version }) {
   // (To whoever has to maintain this, I'm sorry.)
   notes = notes.replaceAll(/(?<=^\s*- [\s\S]*?)\n\s*(?=[^-\s])/gm, ' ');
 
-  // Generate human-friendly release notes
+  return notes;
+}
+
+// Converts the markdown release notes into the human-friendly form used for
+// store submissions.
+function toHumanNotes(notes) {
   let humanNotes = notes;
 
   // 1. Replace markdown bullets with real bullets
@@ -76,27 +101,16 @@ export function formatReleaseNotes({ changeLog, version }) {
   // to keep the text content of all HTML elements.)
   humanNotes = humanNotes.replace(/<kbd>(.+?)<\/kbd>/g, '$1');
 
-  // Generate specific notes for each browser
-  notes += `\n\n<!--\n${getBrowserNotes({
-    notes: humanNotes,
-    supportedBrowsers,
-  })}\n-->`;
-
-  return notes;
+  return humanNotes;
 }
 
-function getVersionHeading({ line, version }) {
+function isVersionHeading({ line, version }) {
   const headingMatch = line.match(/^##\s+(.+?)\s*$/);
   if (!headingMatch) {
-    return null;
+    return false;
   }
 
-  const headingText = headingMatch[1];
-  if (!hasVersionPrefix({ text: headingText, version })) {
-    return null;
-  }
-
-  return { annotation: getTrailingAnnotation(headingText) };
+  return hasVersionPrefix({ text: headingMatch[1], version });
 }
 
 function hasVersionPrefix({ text, version }) {
@@ -112,42 +126,23 @@ function hasVersionPrefix({ text, version }) {
   return false;
 }
 
-function getTrailingAnnotation(text) {
-  const annotationMatch = text.match(/\s+\(([^()]*)\)\s*$/);
-  return annotationMatch?.[1];
-}
-
-const browsers = ['Firefox', 'Chrome', 'Edge', 'Safari', 'Thunderbird'];
-
-function getSupportedBrowsers(annotation) {
-  const listedBrowsers = annotation
-    .replace(/(\s+|-)only$/, '')
-    .split(/\s*,\s*/)
-    .map((b) => b.trim().toLowerCase());
-
-  // Check that it actually is a list of browsers
-  const hasABrowser = browsers.some((browser) =>
-    listedBrowsers.includes(browser.toLowerCase())
-  );
-
-  return hasABrowser ? listedBrowsers : null;
-}
-
-function getBrowserNotes({ notes, supportedBrowsers }) {
+function getBrowserNotes({ notes }) {
   const parts = [];
 
-  const browsersToList = supportedBrowsers
-    ? browsers.filter((b) => supportedBrowsers.includes(b.toLowerCase()))
-    : browsers;
-  for (const browser of browsersToList) {
-    parts.push(`${browser}:\n${getNotesForBrowser({ notes, browser })}`);
+  for (const browser of browsers) {
+    const browserNotes = getNotesForBrowser({ notes, browser });
+    // Omit browsers that have no applicable notes so that the corresponding
+    // store publish step is skipped.
+    if (browserNotes !== null) {
+      parts.push(`${browser}:\n${browserNotes}`);
+    }
   }
 
   return parts.join('\n\n');
 }
 
 // Goes through `notes` and filters out the points that are not relevant to
-// `browser`.
+// `browser`, returning `null` if nothing applies to it.
 function getNotesForBrowser({ notes, browser }) {
   const outputLines = [];
   let droppedParentPoint = false;
@@ -183,11 +178,10 @@ function getNotesForBrowser({ notes, browser }) {
     outputLines.push(line);
   }
 
-  if (!outputLines) {
-    return '(Nothing of interest)';
-  }
-
-  return outputLines.join('\n');
+  // If no actual notes apply to this browser, signal that it should be omitted
+  // entirely.
+  const hasNotes = outputLines.some((line) => /^\s*[•◦]/.test(line));
+  return hasNotes ? outputLines.join('\n') : null;
 }
 
 function filterLine({ line, browser }) {

--- a/scripts/release-notes/format-release-notes.test.js
+++ b/scripts/release-notes/format-release-notes.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatReleaseNotes } from './format-release-notes';
+import { formatReleaseNotes, getReleaseTargets } from './format-release-notes';
 
 describe('formatReleaseNotes', () => {
   it('fetches the matching set of notes', () => {
@@ -113,7 +113,7 @@ Thunderbird:
     expect(notes).not.toContain('- Wrong release.');
   });
 
-  it('handles punctuation and non-normalized dates in annotated version headings', () => {
+  it('matches version headings with punctuation and loose dates, ignoring any trailing annotation', () => {
     const notes = formatReleaseNotes({
       changeLog: `
 ## [1.7.1+test] - 2022-2-10 (Firefox only)
@@ -123,8 +123,11 @@ Thunderbird:
       version: '1.7.1+test',
     });
 
+    // The heading is still located despite the punctuation and non-normalized
+    // date, but the trailing annotation is no longer honoured: an unannotated
+    // note applies to every browser.
     expect(notes).toContain('Firefox:');
-    expect(notes).not.toContain('Chrome:');
+    expect(notes).toContain('Chrome:');
   });
 
   it('merges bullet points that are split across lines', () => {
@@ -250,26 +253,68 @@ Thunderbird:
 -->`);
   });
 
-  it('handles browser-specific releases', () => {
+  it('omits browsers that have no applicable notes', () => {
     expect(
       formatReleaseNotes({
-        changeLog: `## [1.7.2] - 2022-02-10 (Firefox only)
+        changeLog: `## [1.7.2] - 2022-02-10
 
-- Fixed display of the radical meaning in kanji view.
-- Fixed text look up for Google docs when the document is scaled.
+- (Firefox) Fixed display of the radical meaning in kanji view.
+- (Firefox) Fixed text look up for Google docs when the document is scaled.
 
 ## [1.7.0] - 2022-02-05
 
 - Point 1`,
         version: '1.7.2',
       })
-    ).toEqual(`- Fixed display of the radical meaning in kanji view.
-- Fixed text look up for Google docs when the document is scaled.
+    ).toEqual(`- (Firefox) Fixed display of the radical meaning in kanji view.
+- (Firefox) Fixed text look up for Google docs when the document is scaled.
 
 <!--
 Firefox:
 • Fixed display of the radical meaning in kanji view.
 • Fixed text look up for Google docs when the document is scaled.
 -->`);
+  });
+});
+
+describe('getReleaseTargets', () => {
+  it('returns all browsers when notes are unannotated', () => {
+    expect(
+      getReleaseTargets({
+        changeLog: `
+## 1.7.1
+
+- A general fix.
+`,
+        version: '1.7.1',
+      })
+    ).toEqual(['Firefox', 'Chrome', 'Edge', 'Safari', 'Thunderbird']);
+  });
+
+  it('returns only the targeted browsers when every note is restricted', () => {
+    expect(
+      getReleaseTargets({
+        changeLog: `
+## 1.7.1
+
+- (Firefox, Thunderbird) Fixed generation of source artifacts.
+`,
+        version: '1.7.1',
+      })
+    ).toEqual(['Firefox', 'Thunderbird']);
+  });
+
+  it('returns all browsers when at least one note is unannotated', () => {
+    expect(
+      getReleaseTargets({
+        changeLog: `
+## 1.7.1
+
+- (Firefox) A Firefox-only fix.
+- A general fix.
+`,
+        version: '1.7.1',
+      })
+    ).toEqual(['Firefox', 'Chrome', 'Edge', 'Safari', 'Thunderbird']);
   });
 });

--- a/scripts/stamp-changelog-release-date.js
+++ b/scripts/stamp-changelog-release-date.js
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs';
+import * as url from 'node:url';
+
+import {
+  browsers,
+  getReleaseTargets,
+} from './release-notes/format-release-notes.js';
+
+// Stamps the Keep a Changelog release date onto the current version's changelog
+// heading at release time, e.g.
+//
+//   ## 1.28.0  ->  ## [1.28.0] - 2026-06-08
+//
+// During `changeset version` the new release heading is left in its plain
+// `## <version>` form (see `postprocess-changeset-changelog.js` for why).
+//
+// If the release only targets a subset of browsers (because every note is
+// annotated to exclude the others) a human-readable annotation is appended too,
+// e.g.
+//
+//   ## [1.28.0] - 2026-06-08 (Firefox, Thunderbird only)
+//
+// This annotation is purely for the historical record—the actual set of stores
+// a release is published to is driven by which browsers have notes, not by this
+// text. If the heading has already been stamped (or isn't present) the
+// changelog is left unchanged.
+
+/**
+ * Rewrites the plain `## <version>` heading into the dated Keep a Changelog
+ * form, appending a `(… only)` annotation when the release targets a subset of
+ * browsers.
+ *
+ * @param {{ changeLog: string; version: string; date: string }} options
+ * @returns {string}
+ */
+export function stampChangelogReleaseDate({ changeLog, version, date }) {
+  const headingRe = new RegExp(`^## ${escapeRegExp(version)}$`, 'm');
+  if (!headingRe.test(changeLog)) {
+    // Already stamped (or the heading isn't present) — nothing to do.
+    return changeLog;
+  }
+
+  const annotation = formatTargetAnnotation(
+    getReleaseTargets({ changeLog, version })
+  );
+
+  return changeLog.replace(headingRe, `## [${version}] - ${date}${annotation}`);
+}
+
+// Returns a human-readable ` (… only)` annotation when the release targets a
+// strict subset of browsers, or '' when it targets all of them.
+function formatTargetAnnotation(targets) {
+  if (!targets.length || targets.length === browsers.length) {
+    return '';
+  }
+  return ` (${targets.join(', ')} only)`;
+}
+
+function main() {
+  const packageJsonPath = url.fileURLToPath(
+    new URL('../package.json', import.meta.url)
+  );
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const version = packageJson.version;
+  if (!version) {
+    throw new Error('Could not find version in package.json');
+  }
+
+  const changeLogPath = url.fileURLToPath(
+    new URL('../CHANGELOG.md', import.meta.url)
+  );
+  const original = fs.readFileSync(changeLogPath, 'utf8');
+  const date = new Date().toISOString().slice(0, 10);
+  const updated = stampChangelogReleaseDate({
+    changeLog: original,
+    version,
+    date,
+  });
+
+  if (updated === original) {
+    console.log(
+      `No plain "## ${version}" heading to stamp; leaving CHANGELOG.md unchanged.`
+    );
+    return;
+  }
+
+  fs.writeFileSync(changeLogPath, updated, 'utf8');
+  const heading = updated.match(
+    new RegExp(`^## \\[${escapeRegExp(version)}\\].*$`, 'm')
+  )?.[0];
+  console.log(`Stamped CHANGELOG.md heading: ${heading}`);
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Only run the CLI when invoked directly (not when imported by tests).
+if (process.argv[1] === url.fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}

--- a/scripts/stamp-changelog-release-date.test.js
+++ b/scripts/stamp-changelog-release-date.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { stampChangelogReleaseDate } from './stamp-changelog-release-date.js';
+
+const CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+## 1.28.0
+
+- Point 1
+- Point 2
+
+## [1.27.3] - 2026-06-08
+
+- Earlier point
+`;
+
+describe('stampChangelogReleaseDate', () => {
+  it('stamps the date onto the plain version heading', () => {
+    const result = stampChangelogReleaseDate({
+      changeLog: CHANGELOG,
+      version: '1.28.0',
+      date: '2026-06-08',
+    });
+
+    expect(result).toContain('## [1.28.0] - 2026-06-08\n');
+    expect(result).not.toContain('## 1.28.0\n');
+  });
+
+  it('leaves already-dated headings of other versions untouched', () => {
+    const result = stampChangelogReleaseDate({
+      changeLog: CHANGELOG,
+      version: '1.28.0',
+      date: '2026-06-08',
+    });
+
+    expect(result).toContain('## [1.27.3] - 2026-06-08\n');
+  });
+
+  it('does not add an annotation when the release targets all browsers', () => {
+    const result = stampChangelogReleaseDate({
+      changeLog: CHANGELOG,
+      version: '1.28.0',
+      date: '2026-06-08',
+    });
+
+    expect(result).toContain('## [1.28.0] - 2026-06-08\n');
+  });
+
+  it('derives a target annotation when every note is browser-restricted', () => {
+    const changeLog = `# Changelog
+
+## 1.28.0
+
+- (Firefox, Thunderbird) Fixed generation of source artifacts.
+
+## [1.27.3] - 2026-06-08
+
+- Earlier point
+`;
+
+    const result = stampChangelogReleaseDate({
+      changeLog,
+      version: '1.28.0',
+      date: '2026-06-08',
+    });
+
+    expect(result).toContain(
+      '## [1.28.0] - 2026-06-08 (Firefox, Thunderbird only)\n'
+    );
+  });
+
+  it('is a no-op when the heading is already stamped', () => {
+    const changeLog = `# Changelog
+
+## [1.28.0] - 2026-06-08
+
+- Point 1
+`;
+
+    const result = stampChangelogReleaseDate({
+      changeLog,
+      version: '1.28.0',
+      date: '2026-06-09',
+    });
+
+    expect(result).toBe(changeLog);
+  });
+});


### PR DESCRIPTION
The Changesets action locates a release's changelog section by matching
a heading whose text is exactly the version number (e.g. `## 1.28.0`).
Our post-processing rewrote that heading to `## [1.28.0] - <date>`
before the action read it, so the action could no longer find the
section and fell back to embedding the entire CHANGELOG.md in the PR
body. That exceeds Changesets' 60k-character limit, so the body was
replaced with "The changelog information of each package has been
omitted from this message, as the content exceeds the size limit."

Leave the new version's heading in its plain `## <version>` form through
the version bump (so the action can find it) and stamp the Keep a
Changelog date at release time instead.

This pulls a couple of related changes along with it:

- Date stamping moves to the Release workflow.
  `postprocess-changeset-changelog` no longer adds the date; a new
  `scripts/stamp-changelog-release-date.js` (run via
  `pnpm stamp-changelog-date`) rewrites the heading to
  `## [<version>] - <date>` at release time, recording the actual
  release date rather than the PR-update date.

  The release-prep commit now includes CHANGELOG.md, and CHANGELOG.md is
  added to the workflows' push `paths-ignore` so that commit doesn't
  re-trigger CI/Changesets/Release.

- Browser-restricted releases are now driven per note instead of by a
  whole-release heading annotation. A browser with no applicable notes
  is omitted from the generated store notes, so its publish step is
  skipped; to restrict a release, annotate every note with the
  target(s), e.g. `(Firefox)`. The human-readable `(... only)` heading
  annotation is derived from the targeted browsers at stamp time, purely
  for the historical record. `format-release-notes.js` is simplified
  accordingly and gains a `getReleaseTargets` helper.
