### PR TITLE
fix: enable settings button on Firefox for Android >= 153

### DIFF
--- a/.changeset/sparkly-taxes-lay.md
+++ b/.changeset/sparkly-taxes-lay.md
@@ -1,0 +1,5 @@
+---
+'10ten-ja-reader': minor
+---
+
+(Firefox) Enable settings button on popup for Firefox for Android >= 153

--- a/src/content/popup/tabs.ts
+++ b/src/content/popup/tabs.ts
@@ -3,7 +3,7 @@ import browser from 'webextension-polyfill';
 
 import { html } from '../../utils/builder';
 import { getMouseCapabilityMql } from '../../utils/device';
-import { isFenix } from '../../utils/ua-utils';
+import { getFirefoxMajorVersion, isFenix } from '../../utils/ua-utils';
 
 import type { DisplayMode } from '../popup-state';
 import type { QueryResult } from '../query';
@@ -100,15 +100,7 @@ export function renderTabBar({
     tabBar.append(renderPinButton(onTogglePin, pinShortcuts || []));
   }
 
-  // Firefox for Android has a bug that when calling
-  // `browser.runtime.openOptionsPage` a new tab is opened but nothing is
-  // displayed.
-  //
-  // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1795449
-  //
-  // Until that is fixed, we don't show the settings button on Firefox for
-  // Android to avoid confusion.
-  if (onShowSettings && !isFenix()) {
+  if (onShowSettings && canLoadSettingsPage()) {
     tabBar.append(renderSettingsButton(onShowSettings));
   }
 
@@ -135,6 +127,17 @@ function renderPinButton(
   pinButton.onclick = onTogglePin;
 
   return html('div', { class: 'pin' }, pinButton);
+}
+
+function canLoadSettingsPage(): boolean {
+  // Firefox for Android used to have a bug that when calling
+  // `browser.runtime.openOptionsPage` a new tab is opened but nothing is
+  // displayed.
+  //
+  // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1795449
+  //
+  // That was fixed in Firefox 153.
+  return !isFenix() || getFirefoxMajorVersion() >= 153;
 }
 
 function renderSettingsButton(onShowSettings: () => void): HTMLElement {

--- a/src/utils/ua-utils.ts
+++ b/src/utils/ua-utils.ts
@@ -44,3 +44,12 @@ export function isIOS(): boolean {
 export function isThunderbird(): boolean {
   return navigator.userAgent.indexOf('Thunderbird/') !== -1;
 }
+
+/**
+ * Return the major Firefox version parsed from navigator.userAgent, or 0
+ * if Firefox is not detected or the version can't be parsed.
+ */
+export function getFirefoxMajorVersion(): number {
+  const match = navigator.userAgent.match(/\bFirefox\/(\d+)/);
+  return match ? Number(match[1]) : 0;
+}


### PR DESCRIPTION
[Bug 1795449](https://bugzilla.mozilla.org/show_bug.cgi?id=1795449) has
been fixed in Firefox 153. (Thanks @canalun!)
