### PR TITLE
chore: workaround pnpm bug (pin pnpm to 11.11.0)

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -81,7 +82,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/create-safari-test-build.yml
+++ b/.github/workflows/create-safari-test-build.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -71,7 +72,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -120,7 +122,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,8 @@ jobs:
         if: ${{ steps.out.outputs.should_release == 'true' }}
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Install dependencies
         if: ${{ steps.out.outputs.should_release == 'true' }}
@@ -116,7 +117,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - name: Setup node
         uses: actions/setup-node@v6
@@ -306,7 +308,8 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
+          version: 11.11.0
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Problem

CI jobs fail at the **Install pnpm** step with:

```
Switching pnpm from v11.7.0 to v11.12.0...
[ERROR] Cannot use 'in' operator to search for 'integrity' in undefined
##[error]Something went wrong, self-installer exits with code 1
```

`pnpm/action-setup` resolves the floating `version: 11` to the latest 11.x at run time, which flipped to **11.12.0**. That release's self-update/bootstrap logic crashes before pnpm is usable, so every job dies before running. Upstream bug: pnpm/pnpm#12959.

## Fix

Pin every `pnpm/action-setup` block to `11.11.0` (last known-good) across all affected workflows.

## Follow-up

A scheduled routine will open a revert PR to restore the floating `version: 11` once the upstream fix is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
