### PR TITLE
chore: drop pnpm pin (upstream fix released)

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -82,8 +81,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/create-safari-test-build.yml
+++ b/.github/workflows/create-safari-test-build.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -72,8 +71,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -122,8 +120,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,8 +69,7 @@ jobs:
         if: ${{ steps.out.outputs.should_release == 'true' }}
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Install dependencies
         if: ${{ steps.out.outputs.should_release == 'true' }}
@@ -117,8 +116,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -308,8 +306,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          # Pinned below 11.12.0: that release's self-update logic crashes (pnpm/pnpm#12959).
-          version: 11.11.0
+          version: 11
 
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary

- pnpm 11.12.0's self-update logic crashed in CI with `Cannot use 'in' operator to search for 'integrity' in undefined` (pnpm/pnpm#12959), so every `pnpm/action-setup` block across our workflows was pinned to `version: 11.11.0` as a workaround.
- npm now marks 11.12.0 as deprecated ("This release is broken. Please upgrade to v11.13.1 or newer") and the upstream issue is closed, with the fix released starting in pnpm 11.13.1 (current latest: 11.15.0).
- This reverts the pins back to `version: 11` and removes the workaround comment in `ci.yml`, `publish.yml`, `release.yml`, `changesets.yml`, and `create-safari-test-build.yml`.

Upstream issue: https://github.com/pnpm/pnpm/issues/12959

## Test plan

- [ ] CI runs green on this PR with `pnpm/action-setup` resolving to the latest pnpm 11.x (11.15.0) without the self-installer crash


---
_Generated by [Claude Code](https://claude.ai/code/session_01RSLpLSFWM6BLXsPKa7qzta)_