### PR TITLE
fix: workaround Firefox Linux caretPositionFromPoint regression

### DIFF
--- a/.changeset/silly-worlds-punch.md
+++ b/.changeset/silly-worlds-punch.md
@@ -1,0 +1,5 @@
+---
+'10ten-ja-reader': patch
+---
+
+(Firefox) Fixed textarea lookup in Firefox on Linux (#3008).

--- a/src/content/get-cursor-position.ts
+++ b/src/content/get-cursor-position.ts
@@ -368,14 +368,15 @@ function getCaretPosition({
       shadowRoots,
     });
 
-    //
-    // Chrome reports the wrong offset for multi-line <textarea> elements so
-    // fall back to caretRangeFromPoint in that case.
+    // Chromium and Firefox 150+ report the wrong offset for some points in
+    // multi-line <textarea> elements, so fall back to caretRangeFromPoint in
+    // that case.
     //
     // https://issues.chromium.org/issues/446475645
-    //
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=2059340
+    // https://github.com/birchill/10ten-ja-reader/issues/3008
     if (
-      isChromium() &&
+      typeof document.caretRangeFromPoint === 'function' &&
       position?.offsetNode.nodeType === Node.ELEMENT_NODE &&
       (position.offsetNode as Element).tagName === 'TEXTAREA'
     ) {

--- a/src/content/get-text.browser.test.ts
+++ b/src/content/get-text.browser.test.ts
@@ -1149,6 +1149,23 @@ describe('getTextAtPoint', () => {
       expect(result).toBeNull();
     });
 
+    it('does NOT report results in blank textarea rows', () => {
+      // Arrange
+      testDiv.innerHTML = '<textarea rows="10" cols="20">かきくけこ</textarea>';
+      const textAreaNode = testDiv.firstChild as HTMLTextAreaElement;
+
+      makeMonospace(textAreaNode, 20);
+      const bbox = textAreaNode.getBoundingClientRect();
+
+      // Act
+      const result = getTextAtPoint({
+        point: { x: bbox.left + bbox.width / 2, y: bbox.bottom - 10 },
+      });
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
     it('does NOT report results in textarea elements when the mouse is outside', () => {
       // Arrange
       testDiv.innerHTML = '<textarea cols=80>あいうえお</textarea>';


### PR DESCRIPTION
Fixes #3008