### PR TITLE
fix: only fall-back to caretRangeFromPoint on Firefox on Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ Thank you so much for offering to contribute! Here are a few tips that might hel
   Instead it's worth working out if there's a different approach that will work
   well for (nearly) everyone. So far we've been pretty successful at doing that.
 
+- Wrap extended commit messages to 80 characters. The first-line summary may
+  be longer.
+
 # Development
 
 ## Checking out

--- a/src/content/get-cursor-position.ts
+++ b/src/content/get-cursor-position.ts
@@ -11,7 +11,13 @@ import {
   getBboxForSingleCodepointRange,
   getRangeForSingleCodepoint,
 } from '../utils/range';
-import { isChromium } from '../utils/ua-utils';
+import {
+  getChromiumMajorVersion,
+  isChromium,
+  isFirefox,
+  isLinux,
+  isThunderbird,
+} from '../utils/ua-utils';
 
 import { isGdocsOverlayElem } from './gdocs-canvas';
 import { isPopupWindowHostElem } from './popup/popup-container';
@@ -368,14 +374,16 @@ function getCaretPosition({
       shadowRoots,
     });
 
-    // Chromium and Firefox 150+ report the wrong offset for some points in
-    // multi-line <textarea> elements, so fall back to caretRangeFromPoint in
-    // that case.
+    // Chromium before 142 and Firefox / Thunderbird 150+ on Linux report the
+    // wrong offset for some points in multi-line <textarea> elements, so fall
+    // back to caretRangeFromPoint in those cases.
     //
     // https://issues.chromium.org/issues/446475645
     // https://bugzilla.mozilla.org/show_bug.cgi?id=2059340
     // https://github.com/birchill/10ten-ja-reader/issues/3008
     if (
+      ((isChromium() && getChromiumMajorVersion() < 142) ||
+        ((isFirefox() || isThunderbird()) && isLinux())) &&
       typeof document.caretRangeFromPoint === 'function' &&
       position?.offsetNode.nodeType === Node.ELEMENT_NODE &&
       (position.offsetNode as Element).tagName === 'TEXTAREA'

--- a/src/utils/ua-utils.ts
+++ b/src/utils/ua-utils.ts
@@ -13,6 +13,15 @@ export function isChromium(): boolean {
   );
 }
 
+/**
+ * Return the major Chromium version parsed from navigator.userAgent, or 0
+ * if Chromium is not detected or the version can't be parsed.
+ */
+export function getChromiumMajorVersion(): number {
+  const match = navigator.userAgent.match(/\b(?:Chrome|Chromium)\/(\d+)/);
+  return match ? Number(match[1]) : 0;
+}
+
 export function isEdge(): boolean {
   return navigator.userAgent.indexOf('Edg/') !== -1;
 }
@@ -38,6 +47,10 @@ export function isIOS(): boolean {
     // iPad on iOS 13 detection
     (navigator.userAgent.includes('Mac') && 'ontouchend' in document)
   );
+}
+
+export function isLinux(): boolean {
+  return navigator.userAgent.indexOf('Linux') !== -1;
 }
 
 /** @public */


### PR DESCRIPTION
[Chromium issue 446475645](https://issues.chromium.org/issues/446475645)
was fixed in 142 (late 2025) and the Firefox issue has only been
observed on Linux so we should only fall back in that case.
