### PR TITLE
Fetch and play reading audio across browsers

### DIFF
--- a/src/background/background-request.ts
+++ b/src/background/background-request.ts
@@ -17,15 +17,26 @@ const SearchOtherRequestSchema = s.assign(
 
 export type SearchOtherRequest = s.Infer<typeof SearchOtherRequestSchema>;
 
+const TtsClipRequestSchema = s.type({
+  kanji: s.optional(s.string()),
+  reading: s.string(),
+  pitchAccentPos: s.optional(s.number()),
+});
+
 export const BackgroundRequestSchema = discriminator('type', {
   //
   // Requests for the background page
   //
   canHoverChanged: s.type({ value: s.boolean() }),
+  cancelTtsFetch: s.type({ requestId: s.string() }),
   disabled: s.type({}),
   disableMouseInteraction: s.type({}),
   'enable?': s.type({}),
   enabled: s.type({ src: s.string() }),
+  fetchTtsClip: s.type({
+    request: TtsClipRequestSchema,
+    requestId: s.string(),
+  }),
   isDbUpdating: s.type({}),
   options: s.type({}),
   puckStateChanged: s.type({

--- a/src/background/background-request.ts
+++ b/src/background/background-request.ts
@@ -38,7 +38,6 @@ export const BackgroundRequestSchema = discriminator('type', {
     requestId: s.string(),
   }),
   isDbUpdating: s.type({}),
-  notifyTtsWarning: s.type({ message: s.string() }),
   options: s.type({}),
   puckStateChanged: s.type({
     value: s.object({

--- a/src/background/background-request.ts
+++ b/src/background/background-request.ts
@@ -38,6 +38,7 @@ export const BackgroundRequestSchema = discriminator('type', {
     requestId: s.string(),
   }),
   isDbUpdating: s.type({}),
+  notifyTtsWarning: s.type({ message: s.string() }),
   options: s.type({}),
   puckStateChanged: s.type({
     value: s.object({

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -81,6 +81,7 @@ import {
 import { shouldRequestPersistentStorage } from './quota-management';
 import type { SearchOtherResult, SearchWordsResult } from './search-result';
 import TabManager from './tab-manager';
+import { cancelTtsFetch, fetchTtsClip } from './tts-fetch';
 
 //
 // Setup bugsnag
@@ -580,6 +581,29 @@ browser.runtime.onMessage.addListener(
 
       case 'isDbUpdating':
         return Promise.resolve(isDbUpdating());
+
+      case 'fetchTtsClip':
+        if (!sender.tab?.id || typeof sender.frameId !== 'number') {
+          return Promise.resolve({ ok: false });
+        }
+        return fetchTtsClip(
+          {
+            tabId: sender.tab.id,
+            frameId: sender.frameId,
+            requestId: request.requestId,
+          },
+          request.request
+        );
+
+      case 'cancelTtsFetch':
+        if (sender.tab?.id && typeof sender.frameId === 'number') {
+          cancelTtsFetch({
+            tabId: sender.tab.id,
+            frameId: sender.frameId,
+            requestId: request.requestId,
+          });
+        }
+        break;
 
       //
       // Forwarded messages

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -605,6 +605,10 @@ browser.runtime.onMessage.addListener(
         }
         break;
 
+      case 'notifyTtsWarning':
+        void Bugsnag.notify(request.message, { severity: 'warning' });
+        break;
+
       //
       // Forwarded messages
       //

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -605,10 +605,6 @@ browser.runtime.onMessage.addListener(
         }
         break;
 
-      case 'notifyTtsWarning':
-        void Bugsnag.notify(request.message, { severity: 'warning' });
-        break;
-
       //
       // Forwarded messages
       //

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -1,21 +1,28 @@
-import Bugsnag from '@birchill/bugsnag-zero';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { TtsClipRequest } from '../common/tts/tts-request';
 import { buildTtsFilename } from '../common/tts/tts-request';
 
-import type { TtsFetchKey } from './tts-fetch';
-import { cancelTtsFetch, fetchTtsClip } from './tts-fetch';
+import type * as TtsFetch from './tts-fetch';
 
 const request: TtsClipRequest = { kanji: '猫', reading: 'ねこ' };
-const key: TtsFetchKey = { tabId: 1, frameId: 0, requestId: 'clip-1' };
+const key: TtsFetch.TtsFetchKey = { tabId: 1, frameId: 0, requestId: 'clip-1' };
 
 let notifySpy: ReturnType<typeof vi.spyOn>;
+let fetchTtsClip: typeof TtsFetch.fetchTtsClip;
+let cancelTtsFetch: typeof TtsFetch.cancelTtsFetch;
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.useFakeTimers();
+  vi.resetModules();
   vi.stubGlobal('fetch', vi.fn());
+
+  const Bugsnag = (await import('@birchill/bugsnag-zero')).default;
   notifySpy = vi.spyOn(Bugsnag, 'notify').mockResolvedValue(undefined);
+
+  const mod = await import('./tts-fetch');
+  fetchTtsClip = mod.fetchTtsClip;
+  cancelTtsFetch = mod.cancelTtsFetch;
 });
 
 afterEach(() => {
@@ -110,6 +117,42 @@ describe('fetchTtsClip', () => {
     expect(notifySpy).toHaveBeenCalledTimes(1);
   });
 
+  it('stops warning once it has reported its cap of distinct anomalies', async () => {
+    for (let i = 0; i < 40; i++) {
+      mockFetch(
+        makeResponse({
+          headers: {
+            'x-amz-meta-mora-timings': '[0,100]',
+            'x-amz-meta-audio-duration': `${i}x`,
+          },
+          buffer: new Uint8Array([1]).buffer,
+        })
+      );
+      await fetchTtsClip({ ...key, requestId: `clip-${i}` }, request);
+    }
+
+    expect(notifySpy).toHaveBeenCalledTimes(32);
+  });
+
+  it('drops an empty timing array, even when the reading is empty too', async () => {
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[]',
+          'x-amz-meta-audio-duration': '1',
+        },
+        buffer: new Uint8Array([1]).buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, { reading: '' });
+
+    expect(result).toEqual({
+      ok: true,
+      audioBase64: Buffer.from(new Uint8Array([1])).toString('base64'),
+    });
+  });
+
   it('returns no clip, and stays silent, when the reading simply has no audio', async () => {
     mockFetch(makeResponse({ ok: false, status: 404 }));
 
@@ -169,6 +212,10 @@ describe('fetchTtsClip', () => {
   it('skips a TypeError from the body read silently, just like one from fetch() itself', async () => {
     mockFetch(
       makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100]',
+          'x-amz-meta-audio-duration': '300',
+        },
         arrayBuffer: () => Promise.reject(new TypeError('Load failed')),
       })
     );
@@ -213,7 +260,7 @@ describe('fetchTtsClip', () => {
   });
 
   it('leaves a settled fetch`s signal alone when a cancel arrives after it', async () => {
-    const settledKey: TtsFetchKey = {
+    const settledKey: TtsFetch.TtsFetchKey = {
       tabId: 1,
       frameId: 0,
       requestId: 'settled-key',
@@ -227,7 +274,7 @@ describe('fetchTtsClip', () => {
   });
 
   it('cancels only the clip it was asked to, leaving a concurrent fetch running', async () => {
-    const other: TtsFetchKey = { ...key, requestId: 'clip-other' };
+    const other: TtsFetch.TtsFetchKey = { ...key, requestId: 'clip-other' };
     const call = mockFetch();
 
     const pending = fetchTtsClip(key, request);

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -1,0 +1,149 @@
+import Bugsnag from '@birchill/bugsnag-zero';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TtsClipRequest } from '../common/tts/tts-request';
+import { buildTtsFilename } from '../common/tts/tts-request';
+
+import type { TtsFetchKey } from './tts-fetch';
+import { cancelTtsFetch, fetchTtsClip } from './tts-fetch';
+
+const request: TtsClipRequest = { kanji: '猫', reading: 'ねこ' };
+const key: TtsFetchKey = { tabId: 1, frameId: 0, requestId: 'clip-1' };
+
+let notifySpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('fetch', vi.fn());
+  notifySpy = vi.spyOn(Bugsnag, 'notify').mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('fetchTtsClip', () => {
+  it('returns the audio and mora timing from a successful fetch', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100,200]',
+          'x-amz-meta-audio-duration': '300',
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+      moraTiming: { charTimingsMs: [0, 100, 200], totalDurationMs: 300 },
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      `https://data.10ten.life/audio/${buildTtsFilename(request)}`,
+      expect.objectContaining({ signal: expect.anything() })
+    );
+  });
+
+  it('returns the clip without mora timing, and warns directly, when timing headers are missing', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(makeResponse({ buffer: bytes.buffer }));
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+    });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
+
+  it('returns the status without a clip when the response is not ok', async () => {
+    mockFetch(makeResponse({ ok: false, status: 404 }));
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false, status: 404 });
+  });
+
+  it('aborts the underlying fetch when canceled while in flight', async () => {
+    const call = mockFetch();
+
+    const pending = fetchTtsClip(key, request);
+    cancelTtsFetch(key);
+
+    expect(call.signal?.aborted).toBe(true);
+    await expect(pending).resolves.toEqual({ ok: false });
+  });
+
+  it('is a no-op, with nothing left to clean up, when canceled after the fetch settles', async () => {
+    const call = mockFetch(makeResponse({ buffer: new ArrayBuffer(0) }));
+
+    await fetchTtsClip(key, request);
+    cancelTtsFetch(key);
+
+    expect(call.signal?.aborted).toBe(false);
+  });
+
+  it('rejects a body over the 2MB cap before encoding it, and warns directly', async () => {
+    mockFetch(makeResponse({ buffer: new ArrayBuffer(2 * 1024 * 1024 + 1) }));
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
+
+  it('aborts the fetch, and returns ok: false, when reading the body exceeds the 10s budget', async () => {
+    mockFetch(makeResponse({ arrayBuffer: () => neverSettles<ArrayBuffer>() }));
+
+    const pending = fetchTtsClip(key, request);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(pending).resolves.toEqual({ ok: false });
+  });
+});
+
+function makeResponse(
+  init: {
+    ok?: boolean;
+    status?: number;
+    headers?: Record<string, string>;
+    buffer?: ArrayBuffer;
+    arrayBuffer?: () => Promise<ArrayBuffer>;
+  } = {}
+): Response {
+  const headers = new Map(Object.entries(init.headers ?? {}));
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    headers: { get: (name: string) => headers.get(name) ?? null },
+    arrayBuffer:
+      init.arrayBuffer ??
+      (() => Promise.resolve(init.buffer ?? new ArrayBuffer(0))),
+  } as unknown as Response;
+}
+
+function mockFetch(response?: Response) {
+  const call: { signal: AbortSignal | undefined } = { signal: undefined };
+  vi.mocked(fetch).mockImplementation((_url, init) => {
+    call.signal = (init as RequestInit | undefined)?.signal ?? undefined;
+    return response ? Promise.resolve(response) : neverSettles();
+  });
+  return call;
+}
+
+function neverSettles<T>(): Promise<T> {
+  return new Promise<T>(() => {});
+}

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -202,6 +202,30 @@ describe('fetchTtsClip', () => {
     );
   });
 
+  it('returns the clip without mora timing, and warns directly, when the duration header overflows a safe integer', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100]',
+          'x-amz-meta-audio-duration': '9'.repeat(400),
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+    });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
+
   it('aborts the fetch, and returns ok: false, when reading the body exceeds the 10s budget', async () => {
     mockFetch(makeResponse({ arrayBuffer: () => neverSettles<ArrayBuffer>() }));
 

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -99,7 +99,7 @@ describe('fetchTtsClip', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('skips a plain network failure silently (no notify)', async () => {
+  it('skips a TypeError from fetch() silently, regardless of its message (Chrome wording)', async () => {
     vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
 
     const result = await fetchTtsClip(key, request);
@@ -108,7 +108,16 @@ describe('fetchTtsClip', () => {
     expect(notifySpy).not.toHaveBeenCalled();
   });
 
-  it('notifies for an unexpected throw that is not a recognized network failure', async () => {
+  it('skips a TypeError from fetch() silently, regardless of its message (Safari wording)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Load failed'));
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  it('notifies when fetch() itself throws something other than a TypeError', async () => {
     const error = new Error('boom');
     vi.mocked(fetch).mockRejectedValue(error);
 
@@ -116,6 +125,19 @@ describe('fetchTtsClip', () => {
 
     expect(result).toEqual({ ok: false });
     expect(notifySpy).toHaveBeenCalledWith(error);
+  });
+
+  it('notifies when encoding the clip throws, even though the fetch itself succeeded', async () => {
+    mockFetch(makeResponse({ buffer: new Uint8Array([1, 2, 3]).buffer }));
+    const encodeError = new TypeError('Load failed');
+    vi.stubGlobal('btoa', () => {
+      throw encodeError;
+    });
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).toHaveBeenCalledWith(encodeError);
   });
 
   it('aborts the underlying fetch when canceled while in flight', async () => {

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -248,6 +248,62 @@ describe('fetchTtsClip', () => {
     );
   });
 
+  it.each([
+    { shape: 'a negative entry', rawTimings: '[0,-1,200]' },
+    { shape: 'a decreasing pair', rawTimings: '[0,200,100]' },
+    { shape: 'an entry past the total duration', rawTimings: '[0,100,400]' },
+    { shape: 'a non-numeric entry', rawTimings: '[0,"100"]' },
+    { shape: 'no array at all', rawTimings: '{"0":100}' },
+  ])(
+    'returns the clip without mora timing, and warns once, when the timings header has $shape',
+    async ({ rawTimings }) => {
+      const bytes = new Uint8Array([9, 9]);
+      mockFetch(
+        makeResponse({
+          headers: {
+            'x-amz-meta-mora-timings': rawTimings,
+            'x-amz-meta-audio-duration': '300',
+          },
+          buffer: bytes.buffer,
+        })
+      );
+
+      const result = await fetchTtsClip(key, request);
+
+      expect(result).toEqual({
+        ok: true,
+        audio: Buffer.from(bytes).toString('base64'),
+      });
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect(notifySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ severity: 'warning' })
+      );
+    }
+  );
+
+  it('keeps a timing sequence whose adjacent entries repeat, up to the total duration', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100,100,300]',
+          'x-amz-meta-audio-duration': '300',
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+      moraTiming: { charTimingsMs: [0, 100, 100, 300], totalDurationMs: 300 },
+    });
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
   it('aborts the fetch, and returns ok: false, when reading the body exceeds the 10s budget', async () => {
     mockFetch(makeResponse({ arrayBuffer: () => neverSettles<ArrayBuffer>() }));
 

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -74,6 +74,25 @@ describe('fetchTtsClip', () => {
     expect(result).toEqual({ ok: false, status: 404 });
   });
 
+  it('skips a plain network failure silently (no notify)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  it('notifies for an unexpected throw that is not a recognized network failure', async () => {
+    const error = new Error('boom');
+    vi.mocked(fetch).mockRejectedValue(error);
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).toHaveBeenCalledWith(error);
+  });
+
   it('aborts the underlying fetch when canceled while in flight', async () => {
     const call = mockFetch();
 

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -74,6 +74,31 @@ describe('fetchTtsClip', () => {
     expect(result).toEqual({ ok: false, status: 404 });
   });
 
+  it('aborts the controller on a non-OK response, even if its body never finishes downloading', async () => {
+    const call = mockFetch(
+      makeResponse({
+        ok: false,
+        status: 500,
+        arrayBuffer: () => neverSettles<ArrayBuffer>(),
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false, status: 500 });
+    expect(call.signal?.aborted).toBe(true);
+  });
+
+  it('honors a cancel that arrives before its fetchTtsClip registers, without waiting on the network', async () => {
+    mockFetch();
+    cancelTtsFetch(key);
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({ ok: false });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('skips a plain network failure silently (no notify)', async () => {
     vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
 
@@ -103,11 +128,16 @@ describe('fetchTtsClip', () => {
     await expect(pending).resolves.toEqual({ ok: false });
   });
 
-  it('is a no-op, with nothing left to clean up, when canceled after the fetch settles', async () => {
+  it('records a harmless, bounded tombstone, but touches no live signal, when canceled after the fetch settles', async () => {
+    const settledKey: TtsFetchKey = {
+      tabId: 1,
+      frameId: 0,
+      requestId: 'settled-key',
+    };
     const call = mockFetch(makeResponse({ buffer: new ArrayBuffer(0) }));
 
-    await fetchTtsClip(key, request);
-    cancelTtsFetch(key);
+    await fetchTtsClip(settledKey, request);
+    cancelTtsFetch(settledKey);
 
     expect(call.signal?.aborted).toBe(false);
   });
@@ -118,6 +148,54 @@ describe('fetchTtsClip', () => {
     const result = await fetchTtsClip(key, request);
 
     expect(result).toEqual({ ok: false });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
+
+  it('returns the clip without mora timing, and warns directly, when the duration header has trailing non-digit characters', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100]',
+          'x-amz-meta-audio-duration': '300ms',
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+    });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ severity: 'warning' })
+    );
+  });
+
+  it('returns the clip without mora timing, and warns directly, when the duration header is fractional', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100]',
+          'x-amz-meta-audio-duration': '1.5',
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+    });
     expect(notifySpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ severity: 'warning' })

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -30,7 +30,7 @@ describe('fetchTtsClip', () => {
     mockFetch(
       makeResponse({
         headers: {
-          'x-amz-meta-mora-timings': '[0,100,200]',
+          'x-amz-meta-mora-timings': '[0,100]',
           'x-amz-meta-audio-duration': '300',
         },
         buffer: bytes.buffer,
@@ -41,8 +41,8 @@ describe('fetchTtsClip', () => {
 
     expect(result).toEqual({
       ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
-      moraTiming: { charTimingsMs: [0, 100, 200], totalDurationMs: 300 },
+      audioBase64: Buffer.from(bytes).toString('base64'),
+      moraTiming: { charTimingsMs: [0, 100], totalDurationMs: 300 },
     });
     expect(fetch).toHaveBeenCalledWith(
       `https://data.10ten.life/audio/${buildTtsFilename(request)}`,
@@ -58,7 +58,7 @@ describe('fetchTtsClip', () => {
 
     expect(result).toEqual({
       ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
+      audioBase64: Buffer.from(bytes).toString('base64'),
     });
     expect(notifySpy).toHaveBeenCalledWith(
       expect.anything(),
@@ -66,15 +66,60 @@ describe('fetchTtsClip', () => {
     );
   });
 
-  it('returns the status without a clip when the response is not ok', async () => {
+  it('drops timings that do not count one entry per codepoint of the reading', async () => {
+    const bytes = new Uint8Array([9, 9]);
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100,200]',
+          'x-amz-meta-audio-duration': '300',
+        },
+        buffer: bytes.buffer,
+      })
+    );
+
+    const result = await fetchTtsClip(key, request);
+
+    expect(result).toEqual({
+      ok: true,
+      audioBase64: Buffer.from(bytes).toString('base64'),
+    });
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        severity: 'warning',
+        metadata: expect.objectContaining({ expectedCount: 2 }),
+      })
+    );
+  });
+
+  it('warns once for a repeated timing anomaly, however many clips hit it', async () => {
+    mockFetch(
+      makeResponse({
+        headers: {
+          'x-amz-meta-mora-timings': '[0,100,200,300,400]',
+          'x-amz-meta-audio-duration': '500',
+        },
+        buffer: new Uint8Array([7]).buffer,
+      })
+    );
+
+    await fetchTtsClip(key, request);
+    await fetchTtsClip({ ...key, requestId: 'clip-2' }, request);
+
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns no clip, and stays silent, when the reading simply has no audio', async () => {
     mockFetch(makeResponse({ ok: false, status: 404 }));
 
     const result = await fetchTtsClip(key, request);
 
-    expect(result).toEqual({ ok: false, status: 404 });
+    expect(result).toEqual({ ok: false });
+    expect(notifySpy).not.toHaveBeenCalled();
   });
 
-  it('aborts the controller on a non-OK response, even if its body never finishes downloading', async () => {
+  it('warns, with the status, when our own audio service fails', async () => {
     const call = mockFetch(
       makeResponse({
         ok: false,
@@ -85,8 +130,15 @@ describe('fetchTtsClip', () => {
 
     const result = await fetchTtsClip(key, request);
 
-    expect(result).toEqual({ ok: false, status: 500 });
+    expect(result).toEqual({ ok: false });
     expect(call.signal?.aborted).toBe(true);
+    expect(notifySpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        severity: 'warning',
+        metadata: expect.objectContaining({ status: 500 }),
+      })
+    );
   });
 
   it('honors a cancel that arrives before its fetchTtsClip registers, without waiting on the network', async () => {
@@ -99,17 +151,27 @@ describe('fetchTtsClip', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
-  it('skips a TypeError from fetch() silently, regardless of its message (Chrome wording)', async () => {
-    vi.mocked(fetch).mockRejectedValue(new TypeError('Failed to fetch'));
+  it.each([
+    { engine: 'Chrome', message: 'Failed to fetch' },
+    { engine: 'Safari', message: 'Load failed' },
+  ])(
+    'skips a TypeError from fetch() silently, regardless of its message ($engine wording)',
+    async ({ message }) => {
+      vi.mocked(fetch).mockRejectedValue(new TypeError(message));
 
-    const result = await fetchTtsClip(key, request);
+      const result = await fetchTtsClip(key, request);
 
-    expect(result).toEqual({ ok: false });
-    expect(notifySpy).not.toHaveBeenCalled();
-  });
+      expect(result).toEqual({ ok: false });
+      expect(notifySpy).not.toHaveBeenCalled();
+    }
+  );
 
-  it('skips a TypeError from fetch() silently, regardless of its message (Safari wording)', async () => {
-    vi.mocked(fetch).mockRejectedValue(new TypeError('Load failed'));
+  it('skips a TypeError from the body read silently, just like one from fetch() itself', async () => {
+    mockFetch(
+      makeResponse({
+        arrayBuffer: () => Promise.reject(new TypeError('Load failed')),
+      })
+    );
 
     const result = await fetchTtsClip(key, request);
 
@@ -150,7 +212,7 @@ describe('fetchTtsClip', () => {
     await expect(pending).resolves.toEqual({ ok: false });
   });
 
-  it('records a harmless, bounded tombstone, but touches no live signal, when canceled after the fetch settles', async () => {
+  it('leaves a settled fetch`s signal alone when a cancel arrives after it', async () => {
     const settledKey: TtsFetchKey = {
       tabId: 1,
       frameId: 0,
@@ -162,6 +224,22 @@ describe('fetchTtsClip', () => {
     cancelTtsFetch(settledKey);
 
     expect(call.signal?.aborted).toBe(false);
+  });
+
+  it('cancels only the clip it was asked to, leaving a concurrent fetch running', async () => {
+    const other: TtsFetchKey = { ...key, requestId: 'clip-other' };
+    const call = mockFetch();
+
+    const pending = fetchTtsClip(key, request);
+    const otherPending = fetchTtsClip(other, request);
+    cancelTtsFetch(other);
+
+    await expect(otherPending).resolves.toEqual({ ok: false });
+    expect(call.signals[0]?.aborted).toBe(false);
+    expect(call.signals[1]?.aborted).toBe(true);
+
+    cancelTtsFetch(key);
+    await expect(pending).resolves.toEqual({ ok: false });
   });
 
   it('rejects a body over the 2MB cap before encoding it, and warns directly', async () => {
@@ -176,82 +254,41 @@ describe('fetchTtsClip', () => {
     );
   });
 
-  it('returns the clip without mora timing, and warns directly, when the duration header has trailing non-digit characters', async () => {
-    const bytes = new Uint8Array([9, 9]);
-    mockFetch(
-      makeResponse({
-        headers: {
-          'x-amz-meta-mora-timings': '[0,100]',
-          'x-amz-meta-audio-duration': '300ms',
-        },
-        buffer: bytes.buffer,
-      })
-    );
+  it.each([
+    { shape: 'trailing non-digit characters', rawDuration: '300ms' },
+    { shape: 'a fractional value', rawDuration: '1.5' },
+    { shape: 'a value past a safe integer', rawDuration: '9'.repeat(400) },
+  ])(
+    'returns the clip without mora timing, and warns directly, when the duration header has $shape',
+    async ({ rawDuration }) => {
+      const bytes = new Uint8Array([9, 9]);
+      mockFetch(
+        makeResponse({
+          headers: {
+            'x-amz-meta-mora-timings': '[0,100]',
+            'x-amz-meta-audio-duration': rawDuration,
+          },
+          buffer: bytes.buffer,
+        })
+      );
 
-    const result = await fetchTtsClip(key, request);
+      const result = await fetchTtsClip(key, request);
 
-    expect(result).toEqual({
-      ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
-    });
-    expect(notifySpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ severity: 'warning' })
-    );
-  });
-
-  it('returns the clip without mora timing, and warns directly, when the duration header is fractional', async () => {
-    const bytes = new Uint8Array([9, 9]);
-    mockFetch(
-      makeResponse({
-        headers: {
-          'x-amz-meta-mora-timings': '[0,100]',
-          'x-amz-meta-audio-duration': '1.5',
-        },
-        buffer: bytes.buffer,
-      })
-    );
-
-    const result = await fetchTtsClip(key, request);
-
-    expect(result).toEqual({
-      ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
-    });
-    expect(notifySpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ severity: 'warning' })
-    );
-  });
-
-  it('returns the clip without mora timing, and warns directly, when the duration header overflows a safe integer', async () => {
-    const bytes = new Uint8Array([9, 9]);
-    mockFetch(
-      makeResponse({
-        headers: {
-          'x-amz-meta-mora-timings': '[0,100]',
-          'x-amz-meta-audio-duration': '9'.repeat(400),
-        },
-        buffer: bytes.buffer,
-      })
-    );
-
-    const result = await fetchTtsClip(key, request);
-
-    expect(result).toEqual({
-      ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
-    });
-    expect(notifySpy).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ severity: 'warning' })
-    );
-  });
+      expect(result).toEqual({
+        ok: true,
+        audioBase64: Buffer.from(bytes).toString('base64'),
+      });
+      expect(notifySpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ severity: 'warning' })
+      );
+    }
+  );
 
   it.each([
-    { shape: 'a negative entry', rawTimings: '[0,-1,200]' },
-    { shape: 'a decreasing pair', rawTimings: '[0,200,100]' },
-    { shape: 'an entry past the total duration', rawTimings: '[0,100,400]' },
+    { shape: 'a negative entry', rawTimings: '[0,-1]' },
+    { shape: 'a decreasing pair', rawTimings: '[200,100]' },
+    { shape: 'an entry past the total duration', rawTimings: '[0,400]' },
     { shape: 'a non-numeric entry', rawTimings: '[0,"100"]' },
     { shape: 'no array at all', rawTimings: '{"0":100}' },
   ])(
@@ -272,7 +309,7 @@ describe('fetchTtsClip', () => {
 
       expect(result).toEqual({
         ok: true,
-        audio: Buffer.from(bytes).toString('base64'),
+        audioBase64: Buffer.from(bytes).toString('base64'),
       });
       expect(notifySpy).toHaveBeenCalledTimes(1);
       expect(notifySpy).toHaveBeenCalledWith(
@@ -283,23 +320,24 @@ describe('fetchTtsClip', () => {
   );
 
   it('keeps a timing sequence whose adjacent entries repeat, up to the total duration', async () => {
+    const longVowel: TtsClipRequest = { kanji: '学校', reading: 'がっこう' };
     const bytes = new Uint8Array([9, 9]);
     mockFetch(
       makeResponse({
         headers: {
-          'x-amz-meta-mora-timings': '[0,100,100,300]',
-          'x-amz-meta-audio-duration': '300',
+          'x-amz-meta-mora-timings': '[12,151,262,262]',
+          'x-amz-meta-audio-duration': '553',
         },
         buffer: bytes.buffer,
       })
     );
 
-    const result = await fetchTtsClip(key, request);
+    const result = await fetchTtsClip(key, longVowel);
 
     expect(result).toEqual({
       ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
-      moraTiming: { charTimingsMs: [0, 100, 100, 300], totalDurationMs: 300 },
+      audioBase64: Buffer.from(bytes).toString('base64'),
+      moraTiming: { charTimingsMs: [12, 151, 262, 262], totalDurationMs: 553 },
     });
     expect(notifySpy).not.toHaveBeenCalled();
   });
@@ -335,9 +373,13 @@ function makeResponse(
 }
 
 function mockFetch(response?: Response) {
-  const call: { signal: AbortSignal | undefined } = { signal: undefined };
+  const call: {
+    signal: AbortSignal | undefined;
+    signals: Array<AbortSignal | undefined>;
+  } = { signal: undefined, signals: [] };
   vi.mocked(fetch).mockImplementation((_url, init) => {
     call.signal = (init as RequestInit | undefined)?.signal ?? undefined;
+    call.signals.push(call.signal);
     return response ? Promise.resolve(response) : neverSettles();
   });
   return call;

--- a/src/background/tts-fetch.test.ts
+++ b/src/background/tts-fetch.test.ts
@@ -134,25 +134,6 @@ describe('fetchTtsClip', () => {
     expect(notifySpy).toHaveBeenCalledTimes(32);
   });
 
-  it('drops an empty timing array, even when the reading is empty too', async () => {
-    mockFetch(
-      makeResponse({
-        headers: {
-          'x-amz-meta-mora-timings': '[]',
-          'x-amz-meta-audio-duration': '1',
-        },
-        buffer: new Uint8Array([1]).buffer,
-      })
-    );
-
-    const result = await fetchTtsClip(key, { reading: '' });
-
-    expect(result).toEqual({
-      ok: true,
-      audioBase64: Buffer.from(new Uint8Array([1])).toString('base64'),
-    });
-  });
-
   it('returns no clip, and stays silent, when the reading simply has no audio', async () => {
     mockFetch(makeResponse({ ok: false, status: 404 }));
 
@@ -226,16 +207,6 @@ describe('fetchTtsClip', () => {
     expect(notifySpy).not.toHaveBeenCalled();
   });
 
-  it('notifies when fetch() itself throws something other than a TypeError', async () => {
-    const error = new Error('boom');
-    vi.mocked(fetch).mockRejectedValue(error);
-
-    const result = await fetchTtsClip(key, request);
-
-    expect(result).toEqual({ ok: false });
-    expect(notifySpy).toHaveBeenCalledWith(error);
-  });
-
   it('notifies when encoding the clip throws, even though the fetch itself succeeded', async () => {
     mockFetch(makeResponse({ buffer: new Uint8Array([1, 2, 3]).buffer }));
     const encodeError = new TypeError('Load failed');
@@ -247,30 +218,6 @@ describe('fetchTtsClip', () => {
 
     expect(result).toEqual({ ok: false });
     expect(notifySpy).toHaveBeenCalledWith(encodeError);
-  });
-
-  it('aborts the underlying fetch when canceled while in flight', async () => {
-    const call = mockFetch();
-
-    const pending = fetchTtsClip(key, request);
-    cancelTtsFetch(key);
-
-    expect(call.signal?.aborted).toBe(true);
-    await expect(pending).resolves.toEqual({ ok: false });
-  });
-
-  it('leaves a settled fetch`s signal alone when a cancel arrives after it', async () => {
-    const settledKey: TtsFetch.TtsFetchKey = {
-      tabId: 1,
-      frameId: 0,
-      requestId: 'settled-key',
-    };
-    const call = mockFetch(makeResponse({ buffer: new ArrayBuffer(0) }));
-
-    await fetchTtsClip(settledKey, request);
-    cancelTtsFetch(settledKey);
-
-    expect(call.signal?.aborted).toBe(false);
   });
 
   it('cancels only the clip it was asked to, leaving a concurrent fetch running', async () => {
@@ -302,7 +249,6 @@ describe('fetchTtsClip', () => {
   });
 
   it.each([
-    { shape: 'trailing non-digit characters', rawDuration: '300ms' },
     { shape: 'a fractional value', rawDuration: '1.5' },
     { shape: 'a value past a safe integer', rawDuration: '9'.repeat(400) },
   ])(

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -3,7 +3,6 @@ import Bugsnag from '@birchill/bugsnag-zero';
 import type { MoraTimingData, TtsClipRequest } from '../common/tts/tts-request';
 import { buildTtsFilename } from '../common/tts/tts-request';
 import { isAbortError } from '../utils/is-abort-error';
-import { isError } from '../utils/is-error';
 
 const TTS_BASE_URL = 'https://data.10ten.life/audio';
 const CLIP_FETCH_BUDGET_MS = 10_000;
@@ -34,10 +33,21 @@ export async function fetchTtsClip(
 
   try {
     const url = `${TTS_BASE_URL}/${buildTtsFilename(request)}`;
-    const response = await abortable(
-      fetch(url, { signal: controller.signal }),
-      controller.signal
-    );
+    let response: Response;
+    try {
+      response = await abortable(
+        fetch(url, { signal: controller.signal }),
+        controller.signal
+      );
+    } catch (e) {
+      // The Fetch spec ties every TypeError from fetch() itself to a
+      // network failure. Match the error's type here, not engine-specific
+      // wording ("Failed to fetch", "Load failed", ...).
+      if (!isAbortError(e) && e instanceof TypeError) {
+        return { ok: false };
+      }
+      throw e;
+    }
 
     if (!response.ok) {
       controller.abort();
@@ -64,9 +74,7 @@ export async function fetchTtsClip(
     if (isAbortError(e)) {
       return { ok: false };
     }
-    if (!isNetworkError(e)) {
-      void Bugsnag.notify(e);
-    }
+    void Bugsnag.notify(e);
     return { ok: false };
   } finally {
     clearTimeout(deadline);
@@ -165,12 +173,4 @@ function encodeBase64(buffer: ArrayBuffer): string {
     binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
   }
   return btoa(binary);
-}
-
-function isNetworkError(e: unknown): boolean {
-  return (
-    isError(e) &&
-    e instanceof TypeError &&
-    (e.message.startsWith('NetworkError') || e.message === 'Failed to fetch')
-  );
 }

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -1,0 +1,133 @@
+import Bugsnag from '@birchill/bugsnag-zero';
+
+import type { MoraTimingData, TtsClipRequest } from '../common/tts/tts-request';
+import { buildTtsFilename } from '../common/tts/tts-request';
+import { isAbortError } from '../utils/is-abort-error';
+
+const TTS_BASE_URL = 'https://data.10ten.life/audio';
+const CLIP_FETCH_BUDGET_MS = 10_000;
+const MAX_CLIP_BYTES = 2 * 1024 * 1024;
+
+export type TtsFetchResult =
+  | { ok: true; audio: string; moraTiming?: MoraTimingData }
+  | { ok: false; status?: number };
+
+export type TtsFetchKey = { tabId: number; frameId: number; requestId: string };
+
+const pendingFetches = new Map<string, AbortController>();
+
+export async function fetchTtsClip(
+  key: TtsFetchKey,
+  request: TtsClipRequest
+): Promise<TtsFetchResult> {
+  const mapKey = keyFor(key);
+  const controller = new AbortController();
+  pendingFetches.set(mapKey, controller);
+  const deadline = setTimeout(() => controller.abort(), CLIP_FETCH_BUDGET_MS);
+
+  try {
+    const url = `${TTS_BASE_URL}/${buildTtsFilename(request)}`;
+    const response = await abortable(
+      fetch(url, { signal: controller.signal }),
+      controller.signal
+    );
+
+    if (!response.ok) {
+      return { ok: false, status: response.status };
+    }
+
+    const moraTiming = parseMoraTimingHeaders(response);
+
+    const buffer = await abortable(response.arrayBuffer(), controller.signal);
+    if (buffer.byteLength > MAX_CLIP_BYTES) {
+      void Bugsnag.notify(`TTS clip exceeds the ${MAX_CLIP_BYTES}-byte cap`, {
+        severity: 'warning',
+        metadata: { byteLength: buffer.byteLength, url },
+      });
+      return { ok: false };
+    }
+
+    return { ok: true, audio: encodeBase64(buffer), moraTiming };
+  } catch (e) {
+    if (isAbortError(e)) {
+      return { ok: false };
+    }
+    void Bugsnag.notify(e);
+    return { ok: false };
+  } finally {
+    clearTimeout(deadline);
+    if (pendingFetches.get(mapKey) === controller) {
+      pendingFetches.delete(mapKey);
+    }
+  }
+}
+
+export function cancelTtsFetch(key: TtsFetchKey): void {
+  pendingFetches.get(keyFor(key))?.abort();
+}
+
+function keyFor(key: TtsFetchKey): string {
+  return `${key.tabId}:${key.frameId}:${key.requestId}`;
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException('Aborted', 'AbortError'));
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    void promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+function parseMoraTimingHeaders(
+  response: Response
+): MoraTimingData | undefined {
+  const rawTimings = response.headers.get('x-amz-meta-mora-timings');
+  const rawDuration = response.headers.get('x-amz-meta-audio-duration');
+
+  if (!rawTimings || !rawDuration) {
+    void Bugsnag.notify('TTS mora-timing headers missing', {
+      severity: 'warning',
+      metadata: { rawTimings, rawDuration },
+    });
+    return undefined;
+  }
+
+  try {
+    const charTimingsMs: unknown = JSON.parse(rawTimings);
+    const totalDurationMs = parseInt(rawDuration, 10);
+    if (
+      Array.isArray(charTimingsMs) &&
+      charTimingsMs.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
+      Number.isFinite(totalDurationMs)
+    ) {
+      return { charTimingsMs, totalDurationMs };
+    }
+    void Bugsnag.notify('TTS mora-timing headers invalid', {
+      severity: 'warning',
+      metadata: { rawTimings, rawDuration },
+    });
+  } catch (e) {
+    void Bugsnag.notify(
+      new Error('TTS mora-timing headers malformed', { cause: e }),
+      { severity: 'warning', metadata: { rawTimings, rawDuration } }
+    );
+  }
+
+  return undefined;
+}
+
+function encodeBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -34,38 +34,42 @@ export async function fetchTtsClip(
 
   try {
     const url = `${TTS_BASE_URL}/${buildTtsFilename(request)}`;
-    let buffer: ArrayBuffer;
-    let moraTiming: MoraTimingData | undefined;
-    let contentLength: string | null = null;
+
+    let response: Response;
     try {
-      const response = await rejectWhenAborted(
+      response = await rejectWhenAborted(
         fetch(url, { signal: controller.signal }),
         controller.signal
       );
-
-      if (!response.ok) {
-        controller.abort();
-        if (response.status >= 500) {
-          void Bugsnag.notify('TTS clip fetch failed', {
-            severity: 'warning',
-            metadata: { status: response.status },
-          });
-        }
+    } catch (e) {
+      if (isNetworkFailure(e)) {
         return { ok: false };
       }
+      throw e;
+    }
 
-      moraTiming = parseMoraTimingHeaders(response, request.reading);
-      contentLength = response.headers.get('content-length');
+    if (!response.ok) {
+      controller.abort();
+      if (response.status >= 500) {
+        void Bugsnag.notify('TTS clip fetch failed', {
+          severity: 'warning',
+          metadata: { status: response.status },
+        });
+      }
+      return { ok: false };
+    }
 
+    const moraTiming = parseMoraTimingHeaders(response, request.reading);
+    const contentLength = response.headers.get('content-length');
+
+    let buffer: ArrayBuffer;
+    try {
       buffer = await rejectWhenAborted(
         response.arrayBuffer(),
         controller.signal
       );
     } catch (e) {
-      // The Fetch spec ties every TypeError from a fetch, or from reading its
-      // body, to a network failure. Match the error's type here, not
-      // engine-specific wording ("Failed to fetch", "Load failed", ...).
-      if (!isAbortError(e) && e instanceof TypeError) {
+      if (isNetworkFailure(e)) {
         return { ok: false };
       }
       throw e;
@@ -113,6 +117,13 @@ export function cancelTtsFetch(key: TtsFetchKey): void {
 
 function keyFor(key: TtsFetchKey): string {
   return `${key.tabId}:${key.frameId}:${key.requestId}`;
+}
+
+function isNetworkFailure(e: unknown): boolean {
+  // The Fetch spec ties every TypeError from a fetch, or from reading its
+  // body, to a network failure. Match the error's type, not engine-specific
+  // wording ("Failed to fetch", "Load failed", ...).
+  return !isAbortError(e) && e instanceof TypeError;
 }
 
 function parseMoraTimingHeaders(
@@ -167,11 +178,11 @@ function notifyTimingAnomalyOnce(
   metadata: Record<string, unknown>
 ): void {
   const anomaly = `${typeof error === 'string' ? error : error.message}|${JSON.stringify(metadata)}`;
-  if (reportedTimingAnomalies.has(anomaly)) {
+  if (
+    reportedTimingAnomalies.has(anomaly) ||
+    reportedTimingAnomalies.size >= MAX_TIMING_ANOMALY_REPORTS
+  ) {
     return;
-  }
-  if (reportedTimingAnomalies.size >= MAX_TIMING_ANOMALY_REPORTS) {
-    reportedTimingAnomalies.clear();
   }
   reportedTimingAnomalies.add(anomaly);
 
@@ -191,7 +202,11 @@ function parseCharTimingsMs(
   totalDurationMs: number,
   expectedCount: number
 ): Array<number> | undefined {
-  if (!Array.isArray(value) || value.length !== expectedCount) {
+  if (
+    !Array.isArray(value) ||
+    !value.length ||
+    value.length !== expectedCount
+  ) {
     return undefined;
   }
 

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -16,12 +16,18 @@ export type TtsFetchResult =
 export type TtsFetchKey = { tabId: number; frameId: number; requestId: string };
 
 const pendingFetches = new Map<string, AbortController>();
+const cancelledKeys = new Set<string>();
+const MAX_CANCELLED_KEYS = 50;
 
 export async function fetchTtsClip(
   key: TtsFetchKey,
   request: TtsClipRequest
 ): Promise<TtsFetchResult> {
   const mapKey = keyFor(key);
+  if (cancelledKeys.delete(mapKey)) {
+    return { ok: false };
+  }
+
   const controller = new AbortController();
   pendingFetches.set(mapKey, controller);
   const deadline = setTimeout(() => controller.abort(), CLIP_FETCH_BUDGET_MS);
@@ -34,6 +40,7 @@ export async function fetchTtsClip(
     );
 
     if (!response.ok) {
+      controller.abort();
       return { ok: false, status: response.status };
     }
 
@@ -70,7 +77,20 @@ export async function fetchTtsClip(
 }
 
 export function cancelTtsFetch(key: TtsFetchKey): void {
-  pendingFetches.get(keyFor(key))?.abort();
+  const mapKey = keyFor(key);
+  const controller = pendingFetches.get(mapKey);
+  if (controller) {
+    controller.abort();
+    return;
+  }
+
+  cancelledKeys.add(mapKey);
+  if (cancelledKeys.size > MAX_CANCELLED_KEYS) {
+    const oldestKey = cancelledKeys.values().next().value;
+    if (oldestKey !== undefined) {
+      cancelledKeys.delete(oldestKey);
+    }
+  }
 }
 
 function keyFor(key: TtsFetchKey): string {
@@ -107,11 +127,11 @@ function parseMoraTimingHeaders(
 
   try {
     const charTimingsMs: unknown = JSON.parse(rawTimings);
-    const totalDurationMs = parseInt(rawDuration, 10);
+    const totalDurationMs = parseWholeMs(rawDuration);
     if (
       Array.isArray(charTimingsMs) &&
       charTimingsMs.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
-      Number.isFinite(totalDurationMs)
+      totalDurationMs !== undefined
     ) {
       return { charTimingsMs, totalDurationMs };
     }
@@ -127,6 +147,10 @@ function parseMoraTimingHeaders(
   }
 
   return undefined;
+}
+
+function parseWholeMs(value: string): number | undefined {
+  return /^\d+$/.test(value) ? Number(value) : undefined;
 }
 
 function encodeBase64(buffer: ArrayBuffer): string {

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -3,14 +3,15 @@ import Bugsnag from '@birchill/bugsnag-zero';
 import type { MoraTimingData, TtsClipRequest } from '../common/tts/tts-request';
 import { buildTtsFilename } from '../common/tts/tts-request';
 import { isAbortError } from '../utils/is-abort-error';
+import { rejectWhenAborted } from '../utils/reject-when-aborted';
 
 const TTS_BASE_URL = 'https://data.10ten.life/audio';
 const CLIP_FETCH_BUDGET_MS = 10_000;
 const MAX_CLIP_BYTES = 2 * 1024 * 1024;
 
 export type TtsFetchResult =
-  | { ok: true; audio: string; moraTiming?: MoraTimingData }
-  | { ok: false; status?: number };
+  | { ok: true; audioBase64: string; moraTiming?: MoraTimingData }
+  | { ok: false };
 
 export type TtsFetchKey = { tabId: number; frameId: number; requestId: string };
 
@@ -33,43 +34,52 @@ export async function fetchTtsClip(
 
   try {
     const url = `${TTS_BASE_URL}/${buildTtsFilename(request)}`;
-    let response: Response;
+    let buffer: ArrayBuffer;
+    let moraTiming: MoraTimingData | undefined;
+    let contentLength: string | null = null;
     try {
-      response = await abortable(
+      const response = await rejectWhenAborted(
         fetch(url, { signal: controller.signal }),
         controller.signal
       );
+
+      if (!response.ok) {
+        controller.abort();
+        if (response.status >= 500) {
+          void Bugsnag.notify('TTS clip fetch failed', {
+            severity: 'warning',
+            metadata: { status: response.status },
+          });
+        }
+        return { ok: false };
+      }
+
+      moraTiming = parseMoraTimingHeaders(response, request.reading);
+      contentLength = response.headers.get('content-length');
+
+      buffer = await rejectWhenAborted(
+        response.arrayBuffer(),
+        controller.signal
+      );
     } catch (e) {
-      // The Fetch spec ties every TypeError from fetch() itself to a
-      // network failure. Match the error's type here, not engine-specific
-      // wording ("Failed to fetch", "Load failed", ...).
+      // The Fetch spec ties every TypeError from a fetch, or from reading its
+      // body, to a network failure. Match the error's type here, not
+      // engine-specific wording ("Failed to fetch", "Load failed", ...).
       if (!isAbortError(e) && e instanceof TypeError) {
         return { ok: false };
       }
       throw e;
     }
 
-    if (!response.ok) {
-      controller.abort();
-      return { ok: false, status: response.status };
-    }
-
-    const moraTiming = parseMoraTimingHeaders(response);
-
-    const buffer = await abortable(response.arrayBuffer(), controller.signal);
     if (buffer.byteLength > MAX_CLIP_BYTES) {
       void Bugsnag.notify(`TTS clip exceeds the ${MAX_CLIP_BYTES}-byte cap`, {
         severity: 'warning',
-        metadata: {
-          byteLength: buffer.byteLength,
-          status: response.status,
-          contentLength: response.headers.get('content-length'),
-        },
+        metadata: { byteLength: buffer.byteLength, contentLength },
       });
       return { ok: false };
     }
 
-    return { ok: true, audio: encodeBase64(buffer), moraTiming };
+    return { ok: true, audioBase64: encodeBase64(buffer), moraTiming };
   } catch (e) {
     if (isAbortError(e)) {
       return { ok: false };
@@ -105,57 +115,67 @@ function keyFor(key: TtsFetchKey): string {
   return `${key.tabId}:${key.frameId}:${key.requestId}`;
 }
 
-function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
-  if (signal.aborted) {
-    return Promise.reject(new DOMException('Aborted', 'AbortError'));
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(new DOMException('Aborted', 'AbortError'));
-    signal.addEventListener('abort', onAbort, { once: true });
-    void promise.then(resolve, reject).finally(() => {
-      signal.removeEventListener('abort', onAbort);
-    });
-  });
-}
-
 function parseMoraTimingHeaders(
-  response: Response
+  response: Response,
+  reading: string
 ): MoraTimingData | undefined {
   const rawTimings = response.headers.get('x-amz-meta-mora-timings');
   const rawDuration = response.headers.get('x-amz-meta-audio-duration');
 
   if (!rawTimings || !rawDuration) {
-    void Bugsnag.notify('TTS mora-timing headers missing', {
-      severity: 'warning',
-      metadata: { rawTimings, rawDuration },
+    notifyTimingAnomalyOnce('TTS mora-timing headers missing', {
+      rawTimings,
+      rawDuration,
     });
     return undefined;
   }
+
+  const expectedCount = [...reading].length;
 
   try {
     const totalDurationMs = parseWholeMs(rawDuration);
     if (totalDurationMs !== undefined) {
       const charTimingsMs = parseCharTimingsMs(
         JSON.parse(rawTimings),
-        totalDurationMs
+        totalDurationMs,
+        expectedCount
       );
       if (charTimingsMs !== undefined) {
         return { charTimingsMs, totalDurationMs };
       }
     }
-    void Bugsnag.notify('TTS mora-timing headers invalid', {
-      severity: 'warning',
-      metadata: { rawTimings, rawDuration },
+    notifyTimingAnomalyOnce('TTS mora-timing headers invalid', {
+      rawTimings,
+      rawDuration,
+      expectedCount,
     });
   } catch (e) {
-    void Bugsnag.notify(
+    notifyTimingAnomalyOnce(
       new Error('TTS mora-timing headers malformed', { cause: e }),
-      { severity: 'warning', metadata: { rawTimings, rawDuration } }
+      { rawTimings, rawDuration, expectedCount }
     );
   }
 
   return undefined;
+}
+
+const reportedTimingAnomalies = new Set<string>();
+const MAX_TIMING_ANOMALY_REPORTS = 32;
+
+function notifyTimingAnomalyOnce(
+  error: string | Error,
+  metadata: Record<string, unknown>
+): void {
+  const anomaly = `${typeof error === 'string' ? error : error.message}|${JSON.stringify(metadata)}`;
+  if (reportedTimingAnomalies.has(anomaly)) {
+    return;
+  }
+  if (reportedTimingAnomalies.size >= MAX_TIMING_ANOMALY_REPORTS) {
+    reportedTimingAnomalies.clear();
+  }
+  reportedTimingAnomalies.add(anomaly);
+
+  void Bugsnag.notify(error, { severity: 'warning', metadata });
 }
 
 function parseWholeMs(value: string): number | undefined {
@@ -168,9 +188,10 @@ function parseWholeMs(value: string): number | undefined {
 
 function parseCharTimingsMs(
   value: unknown,
-  totalDurationMs: number
+  totalDurationMs: number,
+  expectedCount: number
 ): Array<number> | undefined {
-  if (!Array.isArray(value)) {
+  if (!Array.isArray(value) || value.length !== expectedCount) {
     return undefined;
   }
 

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -150,7 +150,11 @@ function parseMoraTimingHeaders(
 }
 
 function parseWholeMs(value: string): number | undefined {
-  return /^\d+$/.test(value) ? Number(value) : undefined;
+  if (!/^\d+$/.test(value)) {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function encodeBase64(buffer: ArrayBuffer): string {

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -3,6 +3,7 @@ import Bugsnag from '@birchill/bugsnag-zero';
 import type { MoraTimingData, TtsClipRequest } from '../common/tts/tts-request';
 import { buildTtsFilename } from '../common/tts/tts-request';
 import { isAbortError } from '../utils/is-abort-error';
+import { isError } from '../utils/is-error';
 
 const TTS_BASE_URL = 'https://data.10ten.life/audio';
 const CLIP_FETCH_BUDGET_MS = 10_000;
@@ -42,7 +43,11 @@ export async function fetchTtsClip(
     if (buffer.byteLength > MAX_CLIP_BYTES) {
       void Bugsnag.notify(`TTS clip exceeds the ${MAX_CLIP_BYTES}-byte cap`, {
         severity: 'warning',
-        metadata: { byteLength: buffer.byteLength, url },
+        metadata: {
+          byteLength: buffer.byteLength,
+          status: response.status,
+          contentLength: response.headers.get('content-length'),
+        },
       });
       return { ok: false };
     }
@@ -52,7 +57,9 @@ export async function fetchTtsClip(
     if (isAbortError(e)) {
       return { ok: false };
     }
-    void Bugsnag.notify(e);
+    if (!isNetworkError(e)) {
+      void Bugsnag.notify(e);
+    }
     return { ok: false };
   } finally {
     clearTimeout(deadline);
@@ -130,4 +137,12 @@ function encodeBase64(buffer: ArrayBuffer): string {
     binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
   }
   return btoa(binary);
+}
+
+function isNetworkError(e: unknown): boolean {
+  return (
+    isError(e) &&
+    e instanceof TypeError &&
+    (e.message.startsWith('NetworkError') || e.message === 'Failed to fetch')
+  );
 }

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -134,14 +134,15 @@ function parseMoraTimingHeaders(
   }
 
   try {
-    const charTimingsMs: unknown = JSON.parse(rawTimings);
     const totalDurationMs = parseWholeMs(rawDuration);
-    if (
-      Array.isArray(charTimingsMs) &&
-      charTimingsMs.every((n) => typeof n === 'number' && Number.isFinite(n)) &&
-      totalDurationMs !== undefined
-    ) {
-      return { charTimingsMs, totalDurationMs };
+    if (totalDurationMs !== undefined) {
+      const charTimingsMs = parseCharTimingsMs(
+        JSON.parse(rawTimings),
+        totalDurationMs
+      );
+      if (charTimingsMs !== undefined) {
+        return { charTimingsMs, totalDurationMs };
+      }
     }
     void Bugsnag.notify('TTS mora-timing headers invalid', {
       severity: 'warning',
@@ -163,6 +164,33 @@ function parseWholeMs(value: string): number | undefined {
   }
   const parsed = Number(value);
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseCharTimingsMs(
+  value: unknown,
+  totalDurationMs: number
+): Array<number> | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const timings: Array<number> = [];
+  let previous = 0;
+  for (const entry of value) {
+    if (
+      typeof entry !== 'number' ||
+      !Number.isFinite(entry) ||
+      // Equal adjacent values are correct. A long vowel repeats its timestamp.
+      entry < previous ||
+      entry > totalDurationMs
+    ) {
+      return undefined;
+    }
+    timings.push(entry);
+    previous = entry;
+  }
+
+  return timings;
 }
 
 function encodeBase64(buffer: ArrayBuffer): string {

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -8,6 +8,8 @@ import { rejectWhenAborted } from '../utils/reject-when-aborted';
 const TTS_BASE_URL = 'https://data.10ten.life/audio';
 const CLIP_FETCH_BUDGET_MS = 10_000;
 const MAX_CLIP_BYTES = 2 * 1024 * 1024;
+const MAX_CANCELLED_KEYS = 50;
+const MAX_TIMING_ANOMALY_REPORTS = 32;
 
 export type TtsFetchResult =
   | { ok: true; audioBase64: string; moraTiming?: MoraTimingData }
@@ -16,14 +18,16 @@ export type TtsFetchResult =
 export type TtsFetchKey = { tabId: number; frameId: number; requestId: string };
 
 const pendingFetches = new Map<string, AbortController>();
+// Remember cancels that arrive before their matching fetch message.
+// (separate runtime messages are not assumed to arrive in order)
 const cancelledKeys = new Set<string>();
-const MAX_CANCELLED_KEYS = 50;
 
 export async function fetchTtsClip(
   key: TtsFetchKey,
   request: TtsClipRequest
 ): Promise<TtsFetchResult> {
   const mapKey = keyFor(key);
+  // Remove an early cancel and skip its network request.
   if (cancelledKeys.delete(mapKey)) {
     return { ok: false };
   }
@@ -106,6 +110,7 @@ export function cancelTtsFetch(key: TtsFetchKey): void {
     return;
   }
 
+  // The fetch may not have registered yet, so remember this cancel for it.
   cancelledKeys.add(mapKey);
   if (cancelledKeys.size > MAX_CANCELLED_KEYS) {
     const oldestKey = cancelledKeys.values().next().value;
@@ -171,7 +176,6 @@ function parseMoraTimingHeaders(
 }
 
 const reportedTimingAnomalies = new Set<string>();
-const MAX_TIMING_ANOMALY_REPORTS = 32;
 
 function notifyTimingAnomalyOnce(
   error: string | Error,

--- a/src/background/tts-fetch.ts
+++ b/src/background/tts-fetch.ts
@@ -64,7 +64,13 @@ export async function fetchTtsClip(
     }
 
     const moraTiming = parseMoraTimingHeaders(response, request.reading);
+
     const contentLength = response.headers.get('content-length');
+    if (declaresOversizedClip(contentLength)) {
+      controller.abort();
+      notifyOversizedClip({ contentLength });
+      return { ok: false };
+    }
 
     let buffer: ArrayBuffer;
     try {
@@ -80,10 +86,7 @@ export async function fetchTtsClip(
     }
 
     if (buffer.byteLength > MAX_CLIP_BYTES) {
-      void Bugsnag.notify(`TTS clip exceeds the ${MAX_CLIP_BYTES}-byte cap`, {
-        severity: 'warning',
-        metadata: { byteLength: buffer.byteLength, contentLength },
-      });
+      notifyOversizedClip({ byteLength: buffer.byteLength, contentLength });
       return { ok: false };
     }
 
@@ -231,6 +234,21 @@ function parseCharTimingsMs(
   }
 
   return timings;
+}
+
+function declaresOversizedClip(contentLength: string | null): boolean {
+  return (
+    !!contentLength &&
+    /^\d+$/.test(contentLength) &&
+    Number(contentLength) > MAX_CLIP_BYTES
+  );
+}
+
+function notifyOversizedClip(metadata: Record<string, unknown>): void {
+  void Bugsnag.notify(`TTS clip exceeds the ${MAX_CLIP_BYTES}-byte cap`, {
+    severity: 'warning',
+    metadata,
+  });
 }
 
 function encodeBase64(buffer: ArrayBuffer): string {

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -11,12 +11,10 @@ import type { PlayClip } from './tts-player';
 let calls: Array<string>;
 let lastSource: FakeSourceNode | undefined;
 let lastContext: FakeAudioContext | undefined;
-let lastDecodeArg: ArrayBuffer | undefined;
 let contextInstances: number;
 let resumeDeferred: ReturnType<typeof deferred<void>>;
 let decodeDeferred: ReturnType<typeof deferred<AudioBuffer>>;
 let staysAudioSuspended: boolean;
-let connectThrows: boolean;
 let preparePlayback: () => void;
 let playClip: PlayClip;
 
@@ -26,10 +24,8 @@ beforeEach(async () => {
   calls = [];
   lastSource = undefined;
   lastContext = undefined;
-  lastDecodeArg = undefined;
   contextInstances = 0;
   staysAudioSuspended = false;
-  connectThrows = false;
   resumeDeferred = deferred<void>();
   decodeDeferred = deferred<AudioBuffer>();
 
@@ -66,17 +62,6 @@ describe('preparePlayback', () => {
     expect(contextInstances).toBe(1);
     expect(calls).toEqual(['construct', 'resume', 'resume']);
   });
-
-  it('creates a fresh context when the previous one is closed', async () => {
-    preparePlayback();
-    resumeDeferred.resolve();
-    await flush();
-
-    lastContext!.state = 'closed';
-    preparePlayback();
-
-    expect(contextInstances).toBe(2);
-  });
 });
 
 describe('playClip', () => {
@@ -105,20 +90,6 @@ describe('playClip', () => {
     expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  it('copies only the clip view`s bytes into decodeAudioData, not its whole backing buffer', async () => {
-    preparePlayback();
-    resumeDeferred.resolve();
-    await flush();
-
-    const backing = new Uint8Array([9, 9, 1, 2, 3, 9, 9]);
-    const view = backing.subarray(2, 5);
-    const clip: TtsClip = { bytes: view };
-    playClip(clip, new AbortController().signal);
-    await flush();
-
-    expect(new Uint8Array(lastDecodeArg!)).toEqual(new Uint8Array([1, 2, 3]));
-  });
-
   it('rejects immediately, without creating a context, when preparePlayback was never called', async () => {
     const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
     const { started, ended } = playClip(clip, new AbortController().signal);
@@ -138,20 +109,6 @@ describe('playClip', () => {
 
     await expect(started).rejects.toThrow('AudioContext did not resume');
     await expect(ended).rejects.toThrow('AudioContext did not resume');
-    expect(lastSource).toBeUndefined();
-  });
-
-  it('rejects `started` and never starts the source when the signal aborts while resume() is pending', async () => {
-    preparePlayback();
-
-    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
-    const controller = new AbortController();
-    const { started, ended } = playClip(clip, controller.signal);
-
-    controller.abort();
-
-    await expect(started).rejects.toThrow('Clip playback aborted');
-    await expect(ended).rejects.toThrow('Clip playback aborted');
     expect(lastSource).toBeUndefined();
   });
 
@@ -212,37 +169,6 @@ describe('playClip', () => {
     expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
     await expect(ended).rejects.toThrow('Clip playback aborted');
   });
-
-  it('does not let a stop() on a never-started source escape settle()', async () => {
-    preparePlayback();
-    resumeDeferred.resolve();
-    await flush();
-
-    connectThrows = true;
-    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
-    const { started, ended } = playClip(clip, new AbortController().signal);
-    decodeDeferred.resolve({} as AudioBuffer);
-
-    await expect(started).rejects.toThrow('connect failed');
-    await expect(ended).rejects.toThrow('connect failed');
-    expect(lastSource!.stop).toHaveBeenCalledTimes(1);
-  });
-
-  it('reuses the same AudioContext and readiness across clips', async () => {
-    preparePlayback();
-    resumeDeferred.resolve();
-    await flush();
-
-    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
-    playClip(clip, new AbortController().signal);
-    decodeDeferred.resolve({} as AudioBuffer);
-    await flush();
-
-    playClip(clip, new AbortController().signal);
-    await flush();
-
-    expect(contextInstances).toBe(1);
-  });
 });
 
 class FakeAudioContext {
@@ -264,13 +190,10 @@ class FakeAudioContext {
     });
   });
 
-  decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
-    (buffer) => {
-      calls.push('decode');
-      lastDecodeArg = buffer;
-      return decodeDeferred.promise;
-    }
-  );
+  decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(() => {
+    calls.push('decode');
+    return decodeDeferred.promise;
+  });
 
   createBufferSource = vi.fn<() => FakeSourceNode>(() => {
     lastSource = new FakeSourceNode();
@@ -285,28 +208,13 @@ function recordContext(context: FakeAudioContext): void {
 class FakeSourceNode {
   buffer: AudioBuffer | null = null;
   onended: (() => void) | null = null;
-  #started = false;
-
-  connect = vi.fn<() => void>(() => {
-    if (connectThrows) {
-      throw new Error('connect failed');
-    }
-  });
+  connect = vi.fn<() => void>();
 
   start = vi.fn<() => void>(() => {
-    this.#started = true;
     calls.push('start');
   });
 
-  stop = vi.fn<() => void>(() => {
-    if (!this.#started) {
-      throw new DOMException(
-        'cannot call stop without calling start first',
-        'InvalidStateError'
-      );
-    }
-    calls.push('stop');
-  });
+  stop = vi.fn<() => void>(() => calls.push('stop'));
 
   disconnect = vi.fn<() => void>(() => calls.push('disconnect'));
 }

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -226,6 +226,27 @@ describe('playClip', () => {
     expect(lastSource).toBeUndefined();
   });
 
+  it('never starts a source when the signal aborts in the microtask gap right after decode resolves', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const controller = new AbortController();
+    const { started, ended } = playClip(clip, controller.signal);
+    void started.catch(() => {});
+    void ended.catch(() => {});
+    await flush();
+
+    decodeDeferred.resolve({} as AudioBuffer);
+    queueMicrotask(() => controller.abort());
+    await flush();
+
+    await expect(started).rejects.toThrow('Clip playback aborted');
+    await expect(ended).rejects.toThrow('Clip playback aborted');
+    expect(calls).not.toContain('start');
+  });
+
   it('stops and disconnects the source, and rejects `ended`, when the signal aborts mid-playback', async () => {
     preparePlayback();
     resumeDeferred.resolve();

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -10,19 +10,80 @@ import type { PlayClip } from './tts-player';
 
 let calls: Array<string>;
 let lastSource: FakeSourceNode | undefined;
+let lastContext: FakeAudioContext | undefined;
+let lastDecodeArg: ArrayBuffer | undefined;
 let contextInstances: number;
 let resumeDeferred: ReturnType<typeof deferred<void>>;
 let decodeDeferred: ReturnType<typeof deferred<AudioBuffer>>;
+let staysAudioSuspended: boolean;
+let connectThrows: boolean;
 let preparePlayback: () => void;
 let playClip: PlayClip;
 
 class FakeSourceNode {
   buffer: AudioBuffer | null = null;
   onended: (() => void) | null = null;
-  connect = vi.fn<() => void>();
-  start = vi.fn<() => void>(() => calls.push('start'));
-  stop = vi.fn<() => void>(() => calls.push('stop'));
+  #started = false;
+
+  connect = vi.fn<() => void>(() => {
+    if (connectThrows) {
+      throw new Error('connect failed');
+    }
+  });
+
+  start = vi.fn<() => void>(() => {
+    this.#started = true;
+    calls.push('start');
+  });
+
+  stop = vi.fn<() => void>(() => {
+    if (!this.#started) {
+      throw new DOMException(
+        'cannot call stop without calling start first',
+        'InvalidStateError'
+      );
+    }
+    calls.push('stop');
+  });
+
   disconnect = vi.fn<() => void>(() => calls.push('disconnect'));
+}
+
+class FakeAudioContext {
+  state: 'suspended' | 'running' | 'closed' = 'suspended';
+  destination = {};
+
+  constructor() {
+    contextInstances += 1;
+    calls.push('construct');
+    recordContext(this);
+  }
+
+  resume = vi.fn<() => Promise<void>>(() => {
+    calls.push('resume');
+    return resumeDeferred.promise.then(() => {
+      if (!staysAudioSuspended) {
+        this.state = 'running';
+      }
+    });
+  });
+
+  decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
+    (buffer) => {
+      calls.push('decode');
+      lastDecodeArg = buffer;
+      return decodeDeferred.promise;
+    }
+  );
+
+  createBufferSource = vi.fn<() => FakeSourceNode>(() => {
+    lastSource = new FakeSourceNode();
+    return lastSource;
+  });
+}
+
+function recordContext(context: FakeAudioContext): void {
+  lastContext = context;
 }
 
 beforeEach(async () => {
@@ -30,38 +91,13 @@ beforeEach(async () => {
   vi.resetModules();
   calls = [];
   lastSource = undefined;
+  lastContext = undefined;
+  lastDecodeArg = undefined;
   contextInstances = 0;
+  staysAudioSuspended = false;
+  connectThrows = false;
   resumeDeferred = deferred<void>();
   decodeDeferred = deferred<AudioBuffer>();
-
-  class FakeAudioContext {
-    state: 'suspended' | 'running' | 'closed' = 'suspended';
-    destination = {};
-
-    constructor() {
-      contextInstances += 1;
-      calls.push('construct');
-    }
-
-    resume = vi.fn<() => Promise<void>>(() => {
-      calls.push('resume');
-      return resumeDeferred.promise.then(() => {
-        this.state = 'running';
-      });
-    });
-
-    decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
-      () => {
-        calls.push('decode');
-        return decodeDeferred.promise;
-      }
-    );
-
-    createBufferSource = vi.fn<() => FakeSourceNode>(() => {
-      lastSource = new FakeSourceNode();
-      return lastSource;
-    });
-  }
 
   vi.stubGlobal('AudioContext', FakeAudioContext);
 
@@ -83,6 +119,17 @@ describe('preparePlayback', () => {
 
     preparePlayback();
     expect(calls).toEqual(['construct', 'resume', 'resume']);
+  });
+
+  it('creates a fresh context when the previous one is closed', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    lastContext!.state = 'closed';
+    preparePlayback();
+
+    expect(contextInstances).toBe(2);
   });
 });
 
@@ -110,6 +157,56 @@ describe('playClip', () => {
     lastSource!.onended!();
     await expect(ended).resolves.toBeUndefined();
     expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('copies only the clip view`s bytes into decodeAudioData, not its whole backing buffer', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const backing = new Uint8Array([9, 9, 1, 2, 3, 9, 9]);
+    const view = backing.subarray(2, 5);
+    const clip: TtsClip = { bytes: view };
+    playClip(clip, new AbortController().signal);
+    await flush();
+
+    expect(new Uint8Array(lastDecodeArg!)).toEqual(new Uint8Array([1, 2, 3]));
+  });
+
+  it('rejects immediately, without creating a context, when preparePlayback was never called', async () => {
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const { started, ended } = playClip(clip, new AbortController().signal);
+
+    await expect(started).rejects.toThrow('preparePlayback() was not called');
+    await expect(ended).rejects.toThrow('preparePlayback() was not called');
+    expect(contextInstances).toBe(0);
+  });
+
+  it('rejects, instead of hanging, when resume() resolves but the context stays suspended', async () => {
+    staysAudioSuspended = true;
+    preparePlayback();
+    resumeDeferred.resolve();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const { started, ended } = playClip(clip, new AbortController().signal);
+
+    await expect(started).rejects.toThrow('AudioContext did not resume');
+    await expect(ended).rejects.toThrow('AudioContext did not resume');
+    expect(lastSource).toBeUndefined();
+  });
+
+  it('rejects `started` and never starts the source when the signal aborts while resume() is pending', async () => {
+    preparePlayback();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const controller = new AbortController();
+    const { started, ended } = playClip(clip, controller.signal);
+
+    controller.abort();
+
+    await expect(started).rejects.toThrow('Clip playback aborted');
+    await expect(ended).rejects.toThrow('Clip playback aborted');
+    expect(lastSource).toBeUndefined();
   });
 
   it('rejects `started` and never starts the source when the signal aborts before playback begins', async () => {
@@ -147,6 +244,21 @@ describe('playClip', () => {
     expect(lastSource!.stop).toHaveBeenCalledTimes(1);
     expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
     await expect(ended).rejects.toThrow('Clip playback aborted');
+  });
+
+  it('does not let a stop() on a never-started source escape settle()', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    connectThrows = true;
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const { started, ended } = playClip(clip, new AbortController().signal);
+    decodeDeferred.resolve({} as AudioBuffer);
+
+    await expect(started).rejects.toThrow('connect failed');
+    await expect(ended).rejects.toThrow('connect failed');
+    expect(lastSource!.stop).toHaveBeenCalledTimes(1);
   });
 
   it('reuses the same AudioContext and readiness across clips', async () => {

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { TtsClip } from '../../common/tts/tts-request';
+import { withResolvers } from '../../utils/with-resolvers';
 
 import type { PlayClip } from './tts-player';
 
@@ -12,8 +13,8 @@ let calls: Array<string>;
 let lastSource: FakeSourceNode | undefined;
 let lastContext: FakeAudioContext | undefined;
 let contextInstances: number;
-let resumeDeferred: ReturnType<typeof deferred<void>>;
-let decodeDeferred: ReturnType<typeof deferred<AudioBuffer>>;
+let resumeDeferred: ReturnType<typeof withResolvers<void>>;
+let decodeDeferred: ReturnType<typeof withResolvers<AudioBuffer>>;
 let staysAudioSuspended: boolean;
 let preparePlayback: () => void;
 let playClip: PlayClip;
@@ -26,8 +27,8 @@ beforeEach(async () => {
   lastContext = undefined;
   contextInstances = 0;
   staysAudioSuspended = false;
-  resumeDeferred = deferred<void>();
-  decodeDeferred = deferred<AudioBuffer>();
+  resumeDeferred = withResolvers<void>();
+  decodeDeferred = withResolvers<AudioBuffer>();
 
   vi.stubGlobal('AudioContext', FakeAudioContext);
 
@@ -221,14 +222,4 @@ class FakeSourceNode {
 
 function flush() {
   return vi.advanceTimersByTimeAsync(0);
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
 }

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -20,72 +20,6 @@ let connectThrows: boolean;
 let preparePlayback: () => void;
 let playClip: PlayClip;
 
-class FakeSourceNode {
-  buffer: AudioBuffer | null = null;
-  onended: (() => void) | null = null;
-  #started = false;
-
-  connect = vi.fn<() => void>(() => {
-    if (connectThrows) {
-      throw new Error('connect failed');
-    }
-  });
-
-  start = vi.fn<() => void>(() => {
-    this.#started = true;
-    calls.push('start');
-  });
-
-  stop = vi.fn<() => void>(() => {
-    if (!this.#started) {
-      throw new DOMException(
-        'cannot call stop without calling start first',
-        'InvalidStateError'
-      );
-    }
-    calls.push('stop');
-  });
-
-  disconnect = vi.fn<() => void>(() => calls.push('disconnect'));
-}
-
-class FakeAudioContext {
-  state: 'suspended' | 'running' | 'closed' = 'suspended';
-  destination = {};
-
-  constructor() {
-    contextInstances += 1;
-    calls.push('construct');
-    recordContext(this);
-  }
-
-  resume = vi.fn<() => Promise<void>>(() => {
-    calls.push('resume');
-    return resumeDeferred.promise.then(() => {
-      if (!staysAudioSuspended) {
-        this.state = 'running';
-      }
-    });
-  });
-
-  decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
-    (buffer) => {
-      calls.push('decode');
-      lastDecodeArg = buffer;
-      return decodeDeferred.promise;
-    }
-  );
-
-  createBufferSource = vi.fn<() => FakeSourceNode>(() => {
-    lastSource = new FakeSourceNode();
-    return lastSource;
-  });
-}
-
-function recordContext(context: FakeAudioContext): void {
-  lastContext = context;
-}
-
 beforeEach(async () => {
   vi.useFakeTimers();
   vi.resetModules();
@@ -118,6 +52,18 @@ describe('preparePlayback', () => {
     expect(calls).toEqual(['construct', 'resume']);
 
     preparePlayback();
+    expect(calls).toEqual(['construct', 'resume', 'resume']);
+  });
+
+  it('resumes an existing context that WebKit left interrupted', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    lastContext!.state = 'interrupted';
+    preparePlayback();
+
+    expect(contextInstances).toBe(1);
     expect(calls).toEqual(['construct', 'resume', 'resume']);
   });
 
@@ -298,6 +244,72 @@ describe('playClip', () => {
     expect(contextInstances).toBe(1);
   });
 });
+
+class FakeAudioContext {
+  state: AudioContextState = 'suspended';
+  destination = {};
+
+  constructor() {
+    contextInstances += 1;
+    calls.push('construct');
+    recordContext(this);
+  }
+
+  resume = vi.fn<() => Promise<void>>(() => {
+    calls.push('resume');
+    return resumeDeferred.promise.then(() => {
+      if (!staysAudioSuspended) {
+        this.state = 'running';
+      }
+    });
+  });
+
+  decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
+    (buffer) => {
+      calls.push('decode');
+      lastDecodeArg = buffer;
+      return decodeDeferred.promise;
+    }
+  );
+
+  createBufferSource = vi.fn<() => FakeSourceNode>(() => {
+    lastSource = new FakeSourceNode();
+    return lastSource;
+  });
+}
+
+function recordContext(context: FakeAudioContext): void {
+  lastContext = context;
+}
+
+class FakeSourceNode {
+  buffer: AudioBuffer | null = null;
+  onended: (() => void) | null = null;
+  #started = false;
+
+  connect = vi.fn<() => void>(() => {
+    if (connectThrows) {
+      throw new Error('connect failed');
+    }
+  });
+
+  start = vi.fn<() => void>(() => {
+    this.#started = true;
+    calls.push('start');
+  });
+
+  stop = vi.fn<() => void>(() => {
+    if (!this.#started) {
+      throw new DOMException(
+        'cannot call stop without calling start first',
+        'InvalidStateError'
+      );
+    }
+    calls.push('stop');
+  });
+
+  disconnect = vi.fn<() => void>(() => calls.push('disconnect'));
+}
 
 function flush() {
   return vi.advanceTimersByTimeAsync(0);

--- a/src/content/tts/audio-clip-player.test.ts
+++ b/src/content/tts/audio-clip-player.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TtsClip } from '../../common/tts/tts-request';
+
+import type { PlayClip } from './tts-player';
+
+/**
+ * @vitest-environment jsdom
+ */
+
+let calls: Array<string>;
+let lastSource: FakeSourceNode | undefined;
+let contextInstances: number;
+let resumeDeferred: ReturnType<typeof deferred<void>>;
+let decodeDeferred: ReturnType<typeof deferred<AudioBuffer>>;
+let preparePlayback: () => void;
+let playClip: PlayClip;
+
+class FakeSourceNode {
+  buffer: AudioBuffer | null = null;
+  onended: (() => void) | null = null;
+  connect = vi.fn<() => void>();
+  start = vi.fn<() => void>(() => calls.push('start'));
+  stop = vi.fn<() => void>(() => calls.push('stop'));
+  disconnect = vi.fn<() => void>(() => calls.push('disconnect'));
+}
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  vi.resetModules();
+  calls = [];
+  lastSource = undefined;
+  contextInstances = 0;
+  resumeDeferred = deferred<void>();
+  decodeDeferred = deferred<AudioBuffer>();
+
+  class FakeAudioContext {
+    state: 'suspended' | 'running' | 'closed' = 'suspended';
+    destination = {};
+
+    constructor() {
+      contextInstances += 1;
+      calls.push('construct');
+    }
+
+    resume = vi.fn<() => Promise<void>>(() => {
+      calls.push('resume');
+      return resumeDeferred.promise.then(() => {
+        this.state = 'running';
+      });
+    });
+
+    decodeAudioData = vi.fn<(buffer: ArrayBuffer) => Promise<AudioBuffer>>(
+      () => {
+        calls.push('decode');
+        return decodeDeferred.promise;
+      }
+    );
+
+    createBufferSource = vi.fn<() => FakeSourceNode>(() => {
+      lastSource = new FakeSourceNode();
+      return lastSource;
+    });
+  }
+
+  vi.stubGlobal('AudioContext', FakeAudioContext);
+
+  const mod = await import('./audio-clip-player');
+  preparePlayback = mod.preparePlayback;
+  playClip = mod.playClip;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('preparePlayback', () => {
+  it('creates the context and resumes it synchronously, then resumes again while still suspended', () => {
+    preparePlayback();
+    expect(calls).toEqual(['construct', 'resume']);
+
+    preparePlayback();
+    expect(calls).toEqual(['construct', 'resume', 'resume']);
+  });
+});
+
+describe('playClip', () => {
+  it('starts the source only after the clip decodes, then resolves `ended` on `onended`', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const { started, ended } = playClip(clip, new AbortController().signal);
+    void started.then(() => calls.push('started-resolved'));
+
+    await flush();
+    expect(calls).not.toContain('start');
+
+    decodeDeferred.resolve({} as AudioBuffer);
+    await flush();
+
+    expect(calls.indexOf('start')).toBeGreaterThanOrEqual(0);
+    expect(calls.indexOf('start')).toBeLessThan(
+      calls.indexOf('started-resolved')
+    );
+
+    lastSource!.onended!();
+    await expect(ended).resolves.toBeUndefined();
+    expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects `started` and never starts the source when the signal aborts before playback begins', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const controller = new AbortController();
+    const { started, ended } = playClip(clip, controller.signal);
+
+    await flush();
+    controller.abort();
+
+    await expect(started).rejects.toThrow('Clip playback aborted');
+    await expect(ended).rejects.toThrow('Clip playback aborted');
+    expect(lastSource).toBeUndefined();
+  });
+
+  it('stops and disconnects the source, and rejects `ended`, when the signal aborts mid-playback', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    const controller = new AbortController();
+    const { started, ended } = playClip(clip, controller.signal);
+
+    decodeDeferred.resolve({} as AudioBuffer);
+    await flush();
+    await started;
+
+    controller.abort();
+
+    expect(lastSource!.stop).toHaveBeenCalledTimes(1);
+    expect(lastSource!.disconnect).toHaveBeenCalledTimes(1);
+    await expect(ended).rejects.toThrow('Clip playback aborted');
+  });
+
+  it('reuses the same AudioContext and readiness across clips', async () => {
+    preparePlayback();
+    resumeDeferred.resolve();
+    await flush();
+
+    const clip: TtsClip = { bytes: new Uint8Array([1, 2, 3]) };
+    playClip(clip, new AbortController().signal);
+    decodeDeferred.resolve({} as AudioBuffer);
+    await flush();
+
+    playClip(clip, new AbortController().signal);
+    await flush();
+
+    expect(contextInstances).toBe(1);
+  });
+});
+
+function flush() {
+  return vi.advanceTimersByTimeAsync(0);
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/content/tts/audio-clip-player.ts
+++ b/src/content/tts/audio-clip-player.ts
@@ -9,7 +9,24 @@ let prepared: PreparedPlayback | undefined;
 // Do not call this outside a user gesture handler. WebKit keeps the context
 // suspended if the gesture is over.
 export function preparePlayback(): void {
-  ensurePrepared();
+  if (!prepared || prepared.context.state === 'closed') {
+    prepared = createPrepared();
+    return;
+  }
+  if (prepared.context.state === 'suspended') {
+    prepared.ready = resumeTracked(prepared.context);
+  }
+}
+
+function createPrepared(): PreparedPlayback {
+  const context = new AudioContext();
+  return { context, ready: resumeTracked(context) };
+}
+
+function resumeTracked(context: AudioContext): Promise<void> {
+  const ready = context.resume();
+  void ready.catch(() => {});
+  return ready;
 }
 
 export const playClip: PlayClip = (clip, signal) => {
@@ -17,6 +34,18 @@ export const playClip: PlayClip = (clip, signal) => {
   const ended = deferred<void>();
   let source: AudioBufferSourceNode | undefined;
   let settled = false;
+
+  const stopQuietly = () => {
+    try {
+      source?.stop();
+    } catch {}
+  };
+
+  const disconnectQuietly = () => {
+    try {
+      source?.disconnect();
+    } catch {}
+  };
 
   const settle = (error?: unknown) => {
     if (settled) {
@@ -26,13 +55,13 @@ export const playClip: PlayClip = (clip, signal) => {
     signal.removeEventListener('abort', onAbort);
 
     if (error === undefined) {
-      source?.disconnect();
+      disconnectQuietly();
       ended.resolve();
       return;
     }
 
-    source?.stop();
-    source?.disconnect();
+    stopQuietly();
+    disconnectQuietly();
     started.reject(error);
     ended.reject(error);
   };
@@ -46,12 +75,18 @@ export const playClip: PlayClip = (clip, signal) => {
 
   async function run() {
     try {
-      const playback = ensurePrepared();
+      if (!prepared) {
+        throw new Error('preparePlayback() was not called');
+      }
+      const playback = prepared;
       await rejectWhenAborted(playback.ready, signal);
+      if (playback.context.state !== 'running') {
+        throw new Error('AudioContext did not resume');
+      }
 
       const audioBuffer = await rejectWhenAborted(
         playback.context.decodeAudioData(
-          clip.bytes.buffer.slice(0) as ArrayBuffer
+          clip.bytes.slice().buffer as ArrayBuffer
         ),
         signal
       );
@@ -68,16 +103,6 @@ export const playClip: PlayClip = (clip, signal) => {
     }
   }
 };
-
-function ensurePrepared(): PreparedPlayback {
-  if (!prepared) {
-    const context = new AudioContext();
-    prepared = { context, ready: context.resume() };
-  } else if (prepared.context.state === 'suspended') {
-    prepared.ready = prepared.context.resume();
-  }
-  return prepared;
-}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;

--- a/src/content/tts/audio-clip-player.ts
+++ b/src/content/tts/audio-clip-player.ts
@@ -1,0 +1,90 @@
+import { rejectWhenAborted } from '../../utils/reject-when-aborted';
+
+import type { PlayClip, StartInfo } from './tts-player';
+
+type PreparedPlayback = { context: AudioContext; ready: Promise<void> };
+
+let prepared: PreparedPlayback | undefined;
+
+// Do not call this outside a user gesture handler. WebKit keeps the context
+// suspended if the gesture is over.
+export function preparePlayback(): void {
+  ensurePrepared();
+}
+
+export const playClip: PlayClip = (clip, signal) => {
+  const started = deferred<StartInfo>();
+  const ended = deferred<void>();
+  let source: AudioBufferSourceNode | undefined;
+  let settled = false;
+
+  const settle = (error?: unknown) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    signal.removeEventListener('abort', onAbort);
+
+    if (error === undefined) {
+      source?.disconnect();
+      ended.resolve();
+      return;
+    }
+
+    source?.stop();
+    source?.disconnect();
+    started.reject(error);
+    ended.reject(error);
+  };
+
+  const onAbort = () => settle(new Error('Clip playback aborted'));
+  signal.addEventListener('abort', onAbort);
+
+  void run();
+
+  return { started: started.promise, ended: ended.promise };
+
+  async function run() {
+    try {
+      const playback = ensurePrepared();
+      await rejectWhenAborted(playback.ready, signal);
+
+      const audioBuffer = await rejectWhenAborted(
+        playback.context.decodeAudioData(
+          clip.bytes.buffer.slice(0) as ArrayBuffer
+        ),
+        signal
+      );
+
+      source = playback.context.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(playback.context.destination);
+      source.onended = () => settle();
+
+      source.start();
+      started.resolve({ startedAt: performance.now() });
+    } catch (e) {
+      settle(e);
+    }
+  }
+};
+
+function ensurePrepared(): PreparedPlayback {
+  if (!prepared) {
+    const context = new AudioContext();
+    prepared = { context, ready: context.resume() };
+  } else if (prepared.context.state === 'suspended') {
+    prepared.ready = prepared.context.resume();
+  }
+  return prepared;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/content/tts/audio-clip-player.ts
+++ b/src/content/tts/audio-clip-player.ts
@@ -6,14 +6,15 @@ type PreparedPlayback = { context: AudioContext; ready: Promise<void> };
 
 let prepared: PreparedPlayback | undefined;
 
-// Do not call this outside a user gesture handler. WebKit keeps the context
-// suspended if the gesture is over.
 export function preparePlayback(): void {
   if (!prepared || prepared.context.state === 'closed') {
     prepared = createPrepared();
     return;
   }
-  if (prepared.context.state === 'suspended') {
+  if (prepared.context.state !== 'running') {
+    // Resume while the user gesture is still on the stack. WebKit keeps the
+    // context suspended for a resume() that arrives after the gesture is over,
+    // so this cannot wait until the clip is ready to play.
     prepared.ready = resumeTracked(prepared.context);
   }
 }
@@ -88,9 +89,7 @@ export const playClip: PlayClip = (clip, signal) => {
       }
 
       const audioBuffer = await rejectWhenAborted(
-        playback.context.decodeAudioData(
-          clip.bytes.slice().buffer as ArrayBuffer
-        ),
+        playback.context.decodeAudioData(clip.bytes.slice().buffer),
         signal
       );
       if (signal.aborted) {

--- a/src/content/tts/audio-clip-player.ts
+++ b/src/content/tts/audio-clip-player.ts
@@ -80,6 +80,9 @@ export const playClip: PlayClip = (clip, signal) => {
       }
       const playback = prepared;
       await rejectWhenAborted(playback.ready, signal);
+      if (signal.aborted) {
+        return;
+      }
       if (playback.context.state !== 'running') {
         throw new Error('AudioContext did not resume');
       }
@@ -90,6 +93,9 @@ export const playClip: PlayClip = (clip, signal) => {
         ),
         signal
       );
+      if (signal.aborted) {
+        return;
+      }
 
       source = playback.context.createBufferSource();
       source.buffer = audioBuffer;

--- a/src/content/tts/audio-clip-player.ts
+++ b/src/content/tts/audio-clip-player.ts
@@ -1,4 +1,5 @@
 import { rejectWhenAborted } from '../../utils/reject-when-aborted';
+import { withResolvers } from '../../utils/with-resolvers';
 
 import type { PlayClip, StartInfo } from './tts-player';
 
@@ -31,8 +32,8 @@ function resumeTracked(context: AudioContext): Promise<void> {
 }
 
 export const playClip: PlayClip = (clip, signal) => {
-  const started = deferred<StartInfo>();
-  const ended = deferred<void>();
+  const started = withResolvers<StartInfo>();
+  const ended = withResolvers<void>();
   let source: AudioBufferSourceNode | undefined;
   let settled = false;
 
@@ -108,13 +109,3 @@ export const playClip: PlayClip = (clip, signal) => {
     }
   }
 };
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}

--- a/src/content/tts/tts-clip-fetcher.test.ts
+++ b/src/content/tts/tts-clip-fetcher.test.ts
@@ -50,6 +50,28 @@ describe('fetchTtsClip', () => {
     ).rejects.toThrow('Clip fetch failed');
   });
 
+  it('rejects cleanly when the background sends no response at all', async () => {
+    sendMessage.mockResolvedValue(undefined);
+
+    await expect(
+      fetchTtsClip(request, new AbortController().signal)
+    ).rejects.toThrow('Clip fetch failed');
+  });
+
+  it('sends a cancel even when the signal is already aborted before the call', async () => {
+    sendMessage.mockResolvedValue(undefined);
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(fetchTtsClip(request, controller.signal)).rejects.toThrow(
+      'Aborted'
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'cancelTtsFetch' })
+    );
+  });
+
   it('sends a cancel and rejects promptly when the signal aborts mid-flight', async () => {
     sendMessage.mockImplementation((message) =>
       message.type === 'fetchTtsClip'

--- a/src/content/tts/tts-clip-fetcher.test.ts
+++ b/src/content/tts/tts-clip-fetcher.test.ts
@@ -92,24 +92,4 @@ describe('fetchTtsClip', () => {
       requestId: (fetchCall[0] as { requestId: string }).requestId,
     });
   });
-
-  it('removes its abort listener once the fetch settles', async () => {
-    sendMessage.mockResolvedValue({
-      ok: true,
-      audioBase64: '',
-    } satisfies TtsFetchResult);
-    const controller = new AbortController();
-    const added = vi.spyOn(controller.signal, 'addEventListener');
-    const removed = vi.spyOn(controller.signal, 'removeEventListener');
-
-    await fetchTtsClip(request, controller.signal);
-
-    expect(added).toHaveBeenCalledWith('abort', expect.any(Function), {
-      once: true,
-    });
-    expect(removed).toHaveBeenCalledWith(
-      'abort',
-      added.mock.calls[0]![1] as EventListener
-    );
-  });
 });

--- a/src/content/tts/tts-clip-fetcher.test.ts
+++ b/src/content/tts/tts-clip-fetcher.test.ts
@@ -30,7 +30,7 @@ describe('fetchTtsClip', () => {
     const moraTiming = { charTimingsMs: [0, 100], totalDurationMs: 200 };
     sendMessage.mockResolvedValue({
       ok: true,
-      audio: Buffer.from(bytes).toString('base64'),
+      audioBase64: Buffer.from(bytes).toString('base64'),
       moraTiming,
     } satisfies TtsFetchResult);
 
@@ -96,7 +96,7 @@ describe('fetchTtsClip', () => {
   it('removes its abort listener once the fetch settles', async () => {
     sendMessage.mockResolvedValue({
       ok: true,
-      audio: '',
+      audioBase64: '',
     } satisfies TtsFetchResult);
     const controller = new AbortController();
     const added = vi.spyOn(controller.signal, 'addEventListener');

--- a/src/content/tts/tts-clip-fetcher.test.ts
+++ b/src/content/tts/tts-clip-fetcher.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BackgroundRequest } from '../../background/background-request';
+import type { TtsFetchResult } from '../../background/tts-fetch';
+import type { TtsClipRequest } from '../../common/tts/tts-request';
+
+import { fetchTtsClip } from './tts-clip-fetcher';
+
+const { sendMessage } = vi.hoisted(() => ({
+  sendMessage: vi.fn<(message: BackgroundRequest) => Promise<unknown>>(),
+}));
+
+vi.mock('webextension-polyfill', () => ({
+  default: { runtime: { sendMessage } },
+}));
+
+const request: TtsClipRequest = { kanji: '猫', reading: 'ねこ' };
+
+beforeEach(() => {
+  sendMessage.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchTtsClip', () => {
+  it('decodes the base64 audio into bytes and passes the mora timing through', async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const moraTiming = { charTimingsMs: [0, 100], totalDurationMs: 200 };
+    sendMessage.mockResolvedValue({
+      ok: true,
+      audio: Buffer.from(bytes).toString('base64'),
+      moraTiming,
+    } satisfies TtsFetchResult);
+
+    const clip = await fetchTtsClip(request, new AbortController().signal);
+
+    expect(clip).toEqual({ bytes, moraTiming });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'fetchTtsClip', request })
+    );
+  });
+
+  it('rejects when the background reports a failed fetch', async () => {
+    sendMessage.mockResolvedValue({ ok: false } satisfies TtsFetchResult);
+
+    await expect(
+      fetchTtsClip(request, new AbortController().signal)
+    ).rejects.toThrow('Clip fetch failed');
+  });
+
+  it('sends a cancel and rejects promptly when the signal aborts mid-flight', async () => {
+    sendMessage.mockImplementation((message) =>
+      message.type === 'fetchTtsClip'
+        ? new Promise(() => {})
+        : Promise.resolve()
+    );
+    const controller = new AbortController();
+
+    const pending = fetchTtsClip(request, controller.signal);
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('Aborted');
+    const [fetchCall, cancelCall] = sendMessage.mock.calls as Array<
+      [BackgroundRequest]
+    >;
+    expect(cancelCall[0]).toEqual({
+      type: 'cancelTtsFetch',
+      requestId: (fetchCall[0] as { requestId: string }).requestId,
+    });
+  });
+
+  it('removes its abort listener once the fetch settles', async () => {
+    sendMessage.mockResolvedValue({
+      ok: true,
+      audio: '',
+    } satisfies TtsFetchResult);
+    const controller = new AbortController();
+    const added = vi.spyOn(controller.signal, 'addEventListener');
+    const removed = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await fetchTtsClip(request, controller.signal);
+
+    expect(added).toHaveBeenCalledWith('abort', expect.any(Function), {
+      once: true,
+    });
+    expect(removed).toHaveBeenCalledWith(
+      'abort',
+      added.mock.calls[0]![1] as EventListener
+    );
+  });
+});

--- a/src/content/tts/tts-clip-fetcher.ts
+++ b/src/content/tts/tts-clip-fetcher.ts
@@ -1,0 +1,60 @@
+import browser from 'webextension-polyfill';
+
+import type { BackgroundRequest } from '../../background/background-request';
+import type { TtsFetchResult } from '../../background/tts-fetch';
+import type { TtsClipRequest } from '../../common/tts/tts-request';
+import { rejectWhenAborted } from '../../utils/reject-when-aborted';
+
+import type { FetchClip } from './tts-player';
+
+export const fetchTtsClip: FetchClip = async (request, signal) => {
+  const requestId = nextRequestId();
+
+  const response = await rejectWhenAborted(
+    sendFetch(request, requestId),
+    signal,
+    () => void sendCancel(requestId)
+  );
+
+  if (!response.ok) {
+    throw new Error('Clip fetch failed');
+  }
+
+  return {
+    bytes: decodeBase64(response.audio),
+    moraTiming: response.moraTiming,
+  };
+};
+
+let requestCounter = 0;
+
+function nextRequestId(): string {
+  requestCounter += 1;
+  return `tts-clip-${requestCounter}`;
+}
+
+function sendFetch(
+  request: TtsClipRequest,
+  requestId: string
+): Promise<TtsFetchResult> {
+  return browser.runtime.sendMessage<BackgroundRequest, TtsFetchResult>({
+    type: 'fetchTtsClip',
+    request,
+    requestId,
+  });
+}
+
+function sendCancel(requestId: string): Promise<void> {
+  return browser.runtime
+    .sendMessage<BackgroundRequest, void>({ type: 'cancelTtsFetch', requestId })
+    .catch(() => {});
+}
+
+function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/src/content/tts/tts-clip-fetcher.ts
+++ b/src/content/tts/tts-clip-fetcher.ts
@@ -44,8 +44,8 @@ function sendFetch(
   >({ type: 'fetchTtsClip', request, requestId });
 }
 
-function sendCancel(requestId: string): Promise<void> {
-  return browser.runtime
+async function sendCancel(requestId: string): Promise<void> {
+  await browser.runtime
     .sendMessage<BackgroundRequest, void>({ type: 'cancelTtsFetch', requestId })
     .catch(() => {});
 }

--- a/src/content/tts/tts-clip-fetcher.ts
+++ b/src/content/tts/tts-clip-fetcher.ts
@@ -21,7 +21,7 @@ export const fetchTtsClip: FetchClip = async (request, signal) => {
   }
 
   return {
-    bytes: decodeBase64(response.audio),
+    bytes: decodeBase64(response.audioBase64),
     moraTiming: response.moraTiming,
   };
 };

--- a/src/content/tts/tts-clip-fetcher.ts
+++ b/src/content/tts/tts-clip-fetcher.ts
@@ -16,7 +16,7 @@ export const fetchTtsClip: FetchClip = async (request, signal) => {
     () => void sendCancel(requestId)
   );
 
-  if (!response.ok) {
+  if (!response?.ok) {
     throw new Error('Clip fetch failed');
   }
 
@@ -26,22 +26,22 @@ export const fetchTtsClip: FetchClip = async (request, signal) => {
   };
 };
 
+const instancePrefix = Math.random().toString(36).slice(2);
 let requestCounter = 0;
 
 function nextRequestId(): string {
   requestCounter += 1;
-  return `tts-clip-${requestCounter}`;
+  return `${instancePrefix}-${requestCounter}`;
 }
 
 function sendFetch(
   request: TtsClipRequest,
   requestId: string
-): Promise<TtsFetchResult> {
-  return browser.runtime.sendMessage<BackgroundRequest, TtsFetchResult>({
-    type: 'fetchTtsClip',
-    request,
-    requestId,
-  });
+): Promise<TtsFetchResult | undefined> {
+  return browser.runtime.sendMessage<
+    BackgroundRequest,
+    TtsFetchResult | undefined
+  >({ type: 'fetchTtsClip', request, requestId });
 }
 
 function sendCancel(requestId: string): Promise<void> {

--- a/src/utils/reject-when-aborted.test.ts
+++ b/src/utils/reject-when-aborted.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { rejectWhenAborted } from './reject-when-aborted';
+
+describe('rejectWhenAborted', () => {
+  it('rejects immediately and runs onAbort when the signal is already aborted', async () => {
+    const onAbort = vi.fn<() => void>();
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      rejectWhenAborted(new Promise(() => {}), controller.signal, onAbort)
+    ).rejects.toThrow('Aborted');
+
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leave an unhandled rejection when the already-aborted fast path drops the passed promise', async () => {
+    let reject!: (reason: unknown) => void;
+    const producedPromise = new Promise((_resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      rejectWhenAborted(producedPromise, controller.signal)
+    ).rejects.toThrow('Aborted');
+
+    reject(new Error('the producer settles late'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  it('runs onAbort and rejects promptly on a mid-flight abort, without waiting for the promise', async () => {
+    const onAbort = vi.fn<() => void>();
+    const controller = new AbortController();
+
+    const pending = rejectWhenAborted(
+      new Promise(() => {}),
+      controller.signal,
+      onAbort
+    );
+    controller.abort();
+
+    await expect(pending).rejects.toThrow('Aborted');
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes its abort listener once the promise settles on its own', async () => {
+    const controller = new AbortController();
+    const added = vi.spyOn(controller.signal, 'addEventListener');
+    const removed = vi.spyOn(controller.signal, 'removeEventListener');
+
+    await rejectWhenAborted(Promise.resolve('value'), controller.signal);
+    await Promise.resolve();
+
+    expect(added).toHaveBeenCalledWith('abort', expect.any(Function), {
+      once: true,
+    });
+    expect(removed).toHaveBeenCalledWith(
+      'abort',
+      added.mock.calls[0]![1] as EventListener
+    );
+  });
+});

--- a/src/utils/reject-when-aborted.ts
+++ b/src/utils/reject-when-aborted.ts
@@ -1,15 +1,18 @@
 export function rejectWhenAborted<T>(
   promise: Promise<T>,
-  signal: AbortSignal
+  signal: AbortSignal,
+  onAbort?: () => void
 ): Promise<T> {
   if (signal.aborted) {
-    void promise.catch(() => {});
+    onAbort?.();
     return Promise.reject(new DOMException('Aborted', 'AbortError'));
   }
 
   return new Promise<T>((resolve, reject) => {
-    const abortListener = () =>
+    const abortListener = () => {
+      onAbort?.();
       reject(new DOMException('Aborted', 'AbortError'));
+    };
     signal.addEventListener('abort', abortListener, { once: true });
     void promise.then(resolve, reject).finally(() => {
       signal.removeEventListener('abort', abortListener);

--- a/src/utils/reject-when-aborted.ts
+++ b/src/utils/reject-when-aborted.ts
@@ -5,6 +5,7 @@ export function rejectWhenAborted<T>(
 ): Promise<T> {
   if (signal.aborted) {
     onAbort?.();
+    void promise.catch(() => {});
     return Promise.reject(new DOMException('Aborted', 'AbortError'));
   }
 

--- a/src/utils/with-resolvers.ts
+++ b/src/utils/with-resolvers.ts
@@ -1,0 +1,32 @@
+export function withResolvers<T>(): PromiseWithResolvers<T> {
+  if (hasWithResolvers(Promise)) {
+    return Promise.withResolvers<T>();
+  }
+
+  let resolve!: PromiseWithResolvers<T>['resolve'];
+  let reject!: PromiseWithResolvers<T>['reject'];
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+type PromiseWithResolvers<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type PromiseConstructorWithResolvers = PromiseConstructor & {
+  withResolvers<T>(): PromiseWithResolvers<T>;
+};
+
+function hasWithResolvers(
+  promiseConstructor: PromiseConstructor
+): promiseConstructor is PromiseConstructorWithResolvers {
+  return (
+    'withResolvers' in promiseConstructor &&
+    typeof promiseConstructor.withResolvers === 'function'
+  );
+}


### PR DESCRIPTION
Why: Reading audio needs to work even when a site's security policy blocks network or media URLs. This PR fetches each clip in the extension's background context, passes the audio to the content script, and plays it with Web Audio. Stopping also cancels work that is no longer needed.

Stack:

- [#3103 Clean up popup components when replacing the popup](https://github.com/birchill/10ten-ja-reader/pull/3103)
- [#3104 Prepare word readings for audio playback](https://github.com/birchill/10ten-ja-reader/pull/3104)
- [#3105 Fetch and play reading audio across browsers](https://github.com/birchill/10ten-ja-reader/pull/3105) (this PR)
- [#3106 Coordinate reading playback within a popup](https://github.com/birchill/10ten-ja-reader/pull/3106)
- [#3129 Add play buttons for word and name readings](https://github.com/birchill/10ten-ja-reader/pull/3129)
- [#3107 Highlight readings as they are spoken](https://github.com/birchill/10ten-ja-reader/pull/3107)
- [#3108 Add settings and shortcuts for reading audio](https://github.com/birchill/10ten-ja-reader/pull/3108)
