### PR TITLE
Coordinate reading playback within a popup

### DIFF
--- a/src/common/config.test.ts
+++ b/src/common/config.test.ts
@@ -215,6 +215,7 @@ describe('Config', () => {
       startCopy: ['c'],
     });
     expect(config.noTextHighlight).toEqual(false);
+    expect(config.playReadings).toEqual(false);
     expect(config.popupStyle).toEqual('default');
     expect(config.posDisplay).toEqual('expl');
     expect(config.readingOnly).toEqual(false);

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -80,6 +80,7 @@ interface Settings {
     puckState?: PuckState;
   };
   noTextHighlight?: boolean;
+  playReadings?: boolean;
   popupStyle?: string;
   posDisplay?: PartOfSpeechDisplay;
   preferredUnits?: 'metric' | 'imperial';
@@ -1068,6 +1069,12 @@ export class Config {
     void browser.storage.sync.set({ noTextHighlight: value });
   }
 
+  // playReadings: Defaults to false
+
+  get playReadings(): boolean {
+    return !!this.#settings.playReadings;
+  }
+
   // popupInteractive (local): Defaults to true
 
   get popupInteractive(): boolean {
@@ -1386,6 +1393,7 @@ export class Config {
       kanjiReferences: this.kanjiReferences,
       keys: this.keysNormalized,
       noTextHighlight: this.noTextHighlight,
+      playReadings: this.playReadings,
       popupInteractive: this.popupInteractive,
       popupStyle: this.popupStyle,
       posDisplay: this.posDisplay,

--- a/src/common/content-config-params.ts
+++ b/src/common/content-config-params.ts
@@ -112,6 +112,9 @@ export interface ContentConfigParams {
   // Prevents highlighting text on hover
   noTextHighlight: boolean;
 
+  // Whether or not the popup can play readings as audio.
+  playReadings: boolean;
+
   // If the popup should be interactive (e.g. response to mouse clicks)
   popupInteractive: boolean;
 

--- a/src/content/content-config.ts
+++ b/src/content/content-config.ts
@@ -166,6 +166,9 @@ export class ContentConfig implements ContentConfigParams {
   get noTextHighlight() {
     return this.#params.noTextHighlight;
   }
+  get playReadings() {
+    return this.#params.playReadings;
+  }
   get popupInteractive() {
     // Even if `this.params.popupInteractive` is false, if there's no mouse we
     // should force it to true.

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -451,12 +451,10 @@ export class ContentHandler {
           break;
 
         case 'playReadings':
-          // Stop before the popup rebuilds without the button that controls
-          // playback, or the audio would keep playing with no way to stop it.
-          if (!value) {
-            this.#ttsPlaybackController?.stop();
-          }
           if (this.isTopMostWindow()) {
+            if (!value) {
+              this.#ttsPlaybackController?.stop();
+            }
             this.updatePopup();
           }
           break;

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -450,6 +450,17 @@ export class ContentHandler {
           this.#puck?.setHandedness(value);
           break;
 
+        case 'playReadings':
+          // Stop before the popup rebuilds without the button that controls
+          // playback, or the audio would keep playing with no way to stop it.
+          if (!value) {
+            this.#ttsPlayback?.stop();
+          }
+          if (this.isTopMostWindow()) {
+            this.updatePopup();
+          }
+          break;
+
         case 'popupInteractive':
           if (this.isTopMostWindow()) {
             // We can't use updatePopup here since it will try to re-use the

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -123,6 +123,11 @@ import type { TextRange } from './text-range';
 import { textRangesEqual } from './text-range';
 import { hasReasonableTimerResolution } from './timer-precision';
 import { TouchClickTracker } from './touch-click-tracker';
+import type { TtsPlaybackHandle } from './tts-playback-controller';
+import { TtsPlaybackController } from './tts-playback-controller';
+import { playClip } from './tts/audio-clip-player';
+import { fetchTtsClip } from './tts/tts-clip-fetcher';
+import { resolveNameTtsParams, resolveTtsParams } from './tts/tts-params';
 
 const enum HoldToShowKeyType {
   None = 0,
@@ -251,6 +256,9 @@ export class ContentHandler {
   // keyboard events to handle and how to interpret them.)
   #copyState: CopyState = { kind: 'inactive' };
 
+  // Reading playback
+  #ttsPlayback: TtsPlaybackController | undefined;
+
   // Manual positioning support
   #popupPositionMode: PopupPositionMode = PopupPositionMode.Auto;
 
@@ -277,6 +285,7 @@ export class ContentHandler {
     window.addEventListener('keyup', this.onKeyUp, { capture: true });
     window.addEventListener('focusin', this.onFocusIn);
     window.addEventListener('fullscreenchange', this.onFullScreenChange);
+    window.addEventListener('pagehide', this.onPageHide);
     window.addEventListener('message', this.onInterFrameMessage, {
       capture: true,
     });
@@ -508,6 +517,7 @@ export class ContentHandler {
     window.removeEventListener('keyup', this.onKeyUp, { capture: true });
     window.removeEventListener('focusin', this.onFocusIn);
     window.removeEventListener('fullscreenchange', this.onFullScreenChange);
+    window.removeEventListener('pagehide', this.onPageHide);
     window.removeEventListener('message', this.onInterFrameMessage, {
       capture: true,
     });
@@ -518,6 +528,8 @@ export class ContentHandler {
 
     this.#textHighlighter.detach();
     this.#copyState = { kind: 'inactive' };
+    this.#ttsPlayback?.stop();
+    this.#ttsPlayback = undefined;
     this.#isPopupExpanded = false;
     this.#safeAreaProvider.destroy();
     this.#touchClickTracker.destroy();
@@ -1332,6 +1344,10 @@ export class ContentHandler {
     }
   };
 
+  onPageHide = () => {
+    this.#ttsPlayback?.stop();
+  };
+
   onInterFrameMessage = (event: MessageEvent) => {
     // NOTE: Please do not add additional messages here.
     //
@@ -1640,6 +1656,7 @@ export class ContentHandler {
     //   how to handle copyMode-specific keystrokes.
     //
     this.#copyState = { kind: 'active', index, mode: trigger };
+    this.#ttsPlayback?.stop();
 
     if (!this.isTopMostWindow()) {
       console.assert(
@@ -1801,6 +1818,7 @@ export class ContentHandler {
     this.#currentPagePoint = undefined;
     this.#lastPointerTarget = null;
     this.#copyState = { kind: 'inactive' };
+    this.#ttsPlayback?.stop();
 
     clearPopupTimeout(this.#popupState);
     this.#popupState = undefined;
@@ -2207,6 +2225,8 @@ export class ContentHandler {
     const { textBoxSizes: pageTextBoxSizes } = this.#currentTargetProps || {};
     const screenTextBoxSizes = selectionSizesToScreenCoords(pageTextBoxSizes);
 
+    const ttsPlayback = this.#syncTtsPlayback();
+
     const popupOptions: ShowPopupOptions = {
       allowOverlap: options.allowOverlap,
       accentDisplay: this.#config.accentDisplay,
@@ -2284,6 +2304,7 @@ export class ContentHandler {
       showRomaji: this.#config.showRomaji,
       switchDictionaryKeys: this.#config.keys.nextDictionary,
       tabDisplay: this.#config.tabDisplay,
+      ttsPlayback,
       waniKaniVocabDisplay: this.#config.waniKaniVocabDisplay,
     };
 
@@ -2345,6 +2366,37 @@ export class ContentHandler {
       type: 'children:popupShown',
       state: childState,
     });
+  }
+
+  #syncTtsPlayback(): TtsPlaybackHandle | undefined {
+    const entries =
+      this.#config.playReadings && this.#currentDict === 'words'
+        ? [
+            ...(this.#currentSearchResult?.words?.data ?? []).map((word) => ({
+              id: word.id,
+              requests: resolveTtsParams(word),
+            })),
+            ...(this.#currentSearchResult?.namePreview?.names ?? []).map(
+              (name) => ({ id: name.id, requests: resolveNameTtsParams(name) })
+            ),
+          ]
+        : this.#config.playReadings && this.#currentDict === 'names'
+          ? (this.#currentSearchResult?.names?.data ?? []).map((name) => ({
+              id: name.id,
+              requests: resolveNameTtsParams(name),
+            }))
+          : [];
+
+    if (entries.length) {
+      this.#ttsPlayback ??= new TtsPlaybackController({
+        fetchClip: fetchTtsClip,
+        playClip,
+      });
+    }
+
+    this.#ttsPlayback?.setEntries(entries);
+
+    return this.#config.playReadings ? this.#ttsPlayback : undefined;
   }
 
   getCursorClearanceAndPos(screenTextBoxSizes: SelectionSizes | undefined) {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -257,7 +257,7 @@ export class ContentHandler {
   #copyState: CopyState = { kind: 'inactive' };
 
   // Reading playback
-  #ttsPlayback: TtsPlaybackController | undefined;
+  #ttsPlaybackController: TtsPlaybackController | undefined;
 
   // Manual positioning support
   #popupPositionMode: PopupPositionMode = PopupPositionMode.Auto;
@@ -454,7 +454,7 @@ export class ContentHandler {
           // Stop before the popup rebuilds without the button that controls
           // playback, or the audio would keep playing with no way to stop it.
           if (!value) {
-            this.#ttsPlayback?.stop();
+            this.#ttsPlaybackController?.stop();
           }
           if (this.isTopMostWindow()) {
             this.updatePopup();
@@ -539,8 +539,8 @@ export class ContentHandler {
 
     this.#textHighlighter.detach();
     this.#copyState = { kind: 'inactive' };
-    this.#ttsPlayback?.stop();
-    this.#ttsPlayback = undefined;
+    this.#ttsPlaybackController?.stop();
+    this.#ttsPlaybackController = undefined;
     this.#isPopupExpanded = false;
     this.#safeAreaProvider.destroy();
     this.#touchClickTracker.destroy();
@@ -1356,7 +1356,7 @@ export class ContentHandler {
   };
 
   onPageHide = () => {
-    this.#ttsPlayback?.stop();
+    this.#ttsPlaybackController?.stop();
   };
 
   onInterFrameMessage = (event: MessageEvent) => {
@@ -1667,7 +1667,7 @@ export class ContentHandler {
     //   how to handle copyMode-specific keystrokes.
     //
     this.#copyState = { kind: 'active', index, mode: trigger };
-    this.#ttsPlayback?.stop();
+    this.#ttsPlaybackController?.stop();
 
     if (!this.isTopMostWindow()) {
       console.assert(
@@ -1829,7 +1829,7 @@ export class ContentHandler {
     this.#currentPagePoint = undefined;
     this.#lastPointerTarget = null;
     this.#copyState = { kind: 'inactive' };
-    this.#ttsPlayback?.stop();
+    this.#ttsPlaybackController?.stop();
 
     clearPopupTimeout(this.#popupState);
     this.#popupState = undefined;
@@ -2399,15 +2399,15 @@ export class ContentHandler {
           : [];
 
     if (entries.length) {
-      this.#ttsPlayback ??= new TtsPlaybackController({
+      this.#ttsPlaybackController ??= new TtsPlaybackController({
         fetchClip: fetchTtsClip,
         playClip,
       });
     }
 
-    this.#ttsPlayback?.setEntries(entries);
+    this.#ttsPlaybackController?.setEntries(entries);
 
-    return this.#config.playReadings ? this.#ttsPlayback : undefined;
+    return this.#config.playReadings ? this.#ttsPlaybackController : undefined;
   }
 
   getCursorClearanceAndPos(screenTextBoxSizes: SelectionSizes | undefined) {

--- a/src/content/popup/show-popup.ts
+++ b/src/content/popup/show-popup.ts
@@ -17,6 +17,7 @@ import type { DisplayMode } from '../popup-state';
 import type { QueryResult } from '../query';
 import { toScreenCoords } from '../scroll-offset';
 import { isForeignObjectElement, isSvgDoc, isSvgSvgElement } from '../svg';
+import type { TtsPlaybackHandle } from '../tts-playback-controller';
 
 import type { CopyState } from './copy-state';
 import {
@@ -79,6 +80,7 @@ export type ShowPopupOptions = {
   showRomaji: boolean;
   switchDictionaryKeys: ReadonlyArray<string>;
   tabDisplay: 'top' | 'left' | 'right' | 'none';
+  ttsPlayback?: TtsPlaybackHandle;
   waniKaniVocabDisplay: 'hide' | 'show-matches';
 };
 

--- a/src/content/tts-playback-controller.test.ts
+++ b/src/content/tts-playback-controller.test.ts
@@ -1,6 +1,3 @@
-import { h } from 'preact';
-import { useEffect, useState } from 'preact/hooks';
-import { act } from 'preact/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type {
@@ -9,15 +6,10 @@ import type {
   TtsClipRequest,
 } from '../common/tts/tts-request';
 
-import { mountPopupComponent, unmountPopupComponents } from './popup/mount';
 import type { TtsEntry, TtsPlaybackState } from './tts-playback-controller';
 import { TtsPlaybackController } from './tts-playback-controller';
 import { preparePlayback } from './tts/audio-clip-player';
 import type { FetchClip, PlayClip, StartInfo } from './tts/tts-player';
-
-/**
- * @vitest-environment jsdom
- */
 
 vi.mock('./tts/audio-clip-player', () => ({
   preparePlayback: vi.fn<() => void>(),
@@ -31,21 +23,17 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
-  document.body.replaceChildren();
 });
 
 describe('TtsPlaybackController', () => {
   it('fetches and marks only the entry it is playing', async () => {
-    const { controller, fetches, buttons, statuses } = await setUp([
-      entryA,
-      entryB,
-    ]);
+    const { controller, fetches, statuses } = setUp([entryA, entryB]);
 
     await flush();
 
     expect(fetches).toEqual([]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
 
     expect(statuses()).toEqual(['idle', 'loading']);
 
@@ -61,25 +49,25 @@ describe('TtsPlaybackController', () => {
   });
 
   it('stops the playing entry when another entry starts', async () => {
-    const { buttons, statuses, playbacks } = await setUp([entryA, entryB]);
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
     expect(playbacks[0].signal.aborted).toBe(true);
     expect(statuses()).toEqual(['idle', 'playing']);
   });
 
-  it('starts the pressed entry while another entry is still loading', async () => {
-    const { controller, buttons, fetches, playbacks, statuses } = await setUp(
+  it('starts the newly toggled entry while another entry is still loading', async () => {
+    const { controller, fetches, playbacks, statuses } = setUp(
       [entryA, entryB],
       { deferFetch: true }
     );
 
-    await press(buttons[0]);
-    await press(buttons[1]);
+    controller.toggle(0);
+    controller.toggle(1);
 
     expect(fetches[0].signal.aborted).toBe(true);
     expect(fetches[1].request).toEqual(entryB.requests[0]);
@@ -96,47 +84,43 @@ describe('TtsPlaybackController', () => {
     });
   });
 
-  it('stops the playing entry when its own button is pressed again', async () => {
-    const { controller, buttons, statuses, playbacks } = await setUp([
-      entryA,
-      entryB,
-    ]);
+  it('stops the playing entry when it is toggled again', async () => {
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
-    await press(buttons[0]);
+    controller.toggle(0);
 
     expect(playbacks[0].signal.aborted).toBe(true);
     expect(statuses()).toEqual(['idle', 'idle']);
     expect(controller.state).toEqual({ kind: 'idle' });
   });
 
-  it('stops a loading entry when its own button is pressed again', async () => {
-    const { controller, buttons, fetches, playbacks } = await setUp(
-      [entryA, entryB],
-      { deferFetch: true }
-    );
+  it('stops a loading entry when it is toggled again', () => {
+    const { controller, fetches, playbacks } = setUp([entryA, entryB], {
+      deferFetch: true,
+    });
 
-    await press(buttons[0]);
-    await press(buttons[0]);
+    controller.toggle(0);
+    controller.toggle(0);
 
     expect(fetches[0].signal.aborted).toBe(true);
     expect(playbacks).toEqual([]);
     expect(controller.state).toEqual({ kind: 'idle' });
   });
 
-  it('plays the entry again when it is pressed while the error shows', async () => {
+  it('plays the entry again when it is toggled while the error shows', async () => {
     let attempts = 0;
-    const { buttons, fetches, statuses } = await setUp([entryA, entryB], {
+    const { controller, fetches, statuses } = setUp([entryA, entryB], {
       failFor: () => ++attempts === 1,
     });
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
     expect(statuses()).toEqual(['idle', 'error']);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
     expect(fetches).toHaveLength(2);
@@ -144,7 +128,7 @@ describe('TtsPlaybackController', () => {
   });
 
   it('reports that audio has started once the first reading plays', async () => {
-    const { controller, buttons, playbacks } = await setUp([
+    const { controller, playbacks } = setUp([
       { id: 4, requests: twoReadings },
       entryB,
     ]);
@@ -155,7 +139,7 @@ describe('TtsPlaybackController', () => {
       }
     });
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
 
     expect(loadingStates).toEqual([false]);
@@ -167,49 +151,42 @@ describe('TtsPlaybackController', () => {
   });
 
   it('still attempts playback when preparing the audio context throws', async () => {
-    const { buttons, statuses } = await setUp([entryA, entryB]);
+    const { controller, statuses } = setUp([entryA, entryB]);
     const warnings = vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.mocked(preparePlayback).mockImplementationOnce(() => {
       throw new Error('no audio context');
     });
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
 
     expect(warnings).toHaveBeenCalled();
     expect(statuses()).toEqual(['playing', 'idle']);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
     expect(statuses()).toEqual(['idle', 'playing']);
   });
 
   it('keeps playing when the entries are set again with the same keys', async () => {
-    const { controller, buttons, statuses } = await setUp([entryA, entryB]);
+    const { controller, statuses } = setUp([entryA, entryB]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
-    await act(() => {
-      controller.setEntries([{ ...entryA }, { ...entryB }]);
-    });
+    controller.setEntries([{ ...entryA }, { ...entryB }]);
 
     expect(statuses()).toEqual(['idle', 'playing']);
   });
 
   it('keeps playing when the entry it is playing moves to another index', async () => {
-    const { controller, buttons, statuses, playbacks } = await setUp([
-      entryA,
-      entryB,
-    ]);
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
-    await act(() => {
-      controller.setEntries([entryB]);
-    });
+    controller.setEntries([entryB]);
 
     expect(playbacks[0].signal.aborted).toBe(false);
     expect(statuses()).toEqual(['playing', 'idle']);
@@ -220,46 +197,36 @@ describe('TtsPlaybackController', () => {
   });
 
   it('stops when the audio of the entry it is playing changes', async () => {
-    const { controller, buttons, statuses, playbacks } = await setUp([
-      entryA,
-      entryB,
-    ]);
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
-    await act(() => {
-      controller.setEntries([entryA, { id: entryB.id, requests: twoReadings }]);
-    });
+    controller.setEntries([entryA, { id: entryB.id, requests: twoReadings }]);
 
     expect(playbacks[0].signal.aborted).toBe(true);
     expect(statuses()).toEqual(['idle', 'idle']);
   });
 
   it('stops when the entry it is playing disappears', async () => {
-    const { controller, buttons, statuses, playbacks } = await setUp([
-      entryA,
-      entryB,
-    ]);
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
 
-    await act(() => {
-      controller.setEntries([]);
-    });
+    controller.setEntries([]);
 
     expect(playbacks[0].signal.aborted).toBe(true);
     expect(statuses()).toEqual(['idle', 'idle']);
   });
 
   it('fetches the clips again when an entry is played after it finished', async () => {
-    const { buttons, fetches, playbacks, statuses } = await setUp([
+    const { controller, fetches, playbacks, statuses } = setUp([
       { id: 4, requests: twoReadings },
       entryB,
     ]);
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
     playbacks[0].end();
     await flush();
@@ -269,32 +236,32 @@ describe('TtsPlaybackController', () => {
     expect(fetches).toHaveLength(2);
     expect(statuses()).toEqual(['idle', 'idle']);
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
 
     expect(fetches).toHaveLength(4);
     expect(statuses()).toEqual(['playing', 'idle']);
   });
 
-  it('shows the current state on an island that mounts while a reading plays', async () => {
-    const { buttons, mountIsland } = await setUp([entryA, entryB]);
+  it('tells a listener the current state when it subscribes while a reading plays', async () => {
+    const { controller, subscribeProbe } = setUp([entryA, entryB]);
 
-    await press(buttons[1]);
+    controller.toggle(1);
     await flush();
-    const late = await mountIsland(1);
+    const late = subscribeProbe(1);
 
-    expect(late.dataset.status).toBe('playing');
+    expect(late.status()).toBe('playing');
   });
 
-  it('stops notifying an island that was unmounted', async () => {
-    const { controller, root, deliveries } = await setUp([entryA, entryB]);
+  it('stops notifying a listener that unsubscribed', async () => {
+    const { controller, deliveries, unsubscribeAll } = setUp([entryA, entryB]);
 
     expect(deliveries).toEqual([
       { entryIndex: 0, kind: 'idle' },
       { entryIndex: 1, kind: 'idle' },
     ]);
 
-    unmountPopupComponents(root);
+    unsubscribeAll();
     controller.toggle(0);
     await flush();
 
@@ -302,7 +269,7 @@ describe('TtsPlaybackController', () => {
   });
 
   it('keeps playing when a listener throws', async () => {
-    const { controller, buttons, statuses } = await setUp([entryA, entryB]);
+    const { controller, statuses } = setUp([entryA, entryB]);
     const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     const seen: Array<string> = [];
     controller.subscribe(() => {
@@ -310,7 +277,7 @@ describe('TtsPlaybackController', () => {
     });
     controller.subscribe((state) => seen.push(state.kind));
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
 
     expect(statuses()).toEqual(['playing', 'idle']);
@@ -319,18 +286,16 @@ describe('TtsPlaybackController', () => {
   });
 
   it('stops when a stop arrives while it starts an entry', async () => {
-    const { controller, buttons, fetches, playbacks, statuses } = await setUp(
+    const { controller, fetches, playbacks, statuses } = setUp(
       [entryA, entryB],
       { deferFetch: true }
     );
 
-    await press(buttons[0]);
+    controller.toggle(0);
 
     expect(statuses()).toEqual(['loading', 'idle']);
 
-    await act(() => {
-      controller.stop();
-    });
+    controller.stop();
     await flush();
 
     expect(fetches[0].signal.aborted).toBe(true);
@@ -340,7 +305,7 @@ describe('TtsPlaybackController', () => {
   });
 
   it('prepares audio playback synchronously on start, and not on stop', async () => {
-    const { controller } = await setUp([entryA, entryB]);
+    const { controller } = setUp([entryA, entryB]);
 
     expect(preparePlayback).not.toHaveBeenCalled();
 
@@ -350,25 +315,18 @@ describe('TtsPlaybackController', () => {
     expect(preparePlayback).toHaveBeenCalledTimes(1);
 
     await flush();
-    await act(() => {
-      controller.toggle(0);
-    });
+    controller.toggle(0);
 
     expect(preparePlayback).toHaveBeenCalledTimes(1);
   });
 
   it('stops playback on stop()', async () => {
-    const { controller, buttons, statuses, playbacks } = await setUp([
-      entryA,
-      entryB,
-    ]);
+    const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
-    await press(buttons[0]);
+    controller.toggle(0);
     await flush();
 
-    await act(() => {
-      controller.stop();
-    });
+    controller.stop();
 
     expect(playbacks[0].signal.aborted).toBe(true);
     expect(statuses()).toEqual(['idle', 'idle']);
@@ -391,9 +349,7 @@ describe('TtsPlaybackController', () => {
     });
     controller.setEntries([entryA]);
 
-    await act(() => {
-      controller.toggle(0);
-    });
+    controller.toggle(0);
     await flush();
 
     expect(controller.state).toMatchObject({ kind: 'playing', startedAt: 123 });
@@ -431,10 +387,7 @@ type FetchCall = {
 
 type PlaybackCall = { clip: TtsClip; signal: AbortSignal; end: () => void };
 
-async function setUp(
-  entries: ReadonlyArray<TtsEntry>,
-  behavior: Behavior = {}
-) {
+function setUp(entries: ReadonlyArray<TtsEntry>, behavior: Behavior = {}) {
   const fetches: Array<FetchCall> = [];
   const playbacks: Array<PlaybackCall> = [];
 
@@ -480,100 +433,50 @@ async function setUp(
   const controller = new TtsPlaybackController({ fetchClip, playClip });
   controller.setEntries(entries);
 
-  const root = document.createElement('div');
-  document.body.append(root);
   const deliveries: Array<{ entryIndex: number; kind: string }> = [];
-  const buttons = [
-    await mountIsland({ root, controller, entryIndex: 0, deliveries }),
-    await mountIsland({ root, controller, entryIndex: 1, deliveries }),
+  const probes = [
+    subscribeProbe({ controller, entryIndex: 0, deliveries }),
+    subscribeProbe({ controller, entryIndex: 1, deliveries }),
   ];
 
   return {
     controller,
     fetches,
     playbacks,
-    buttons,
     deliveries,
-    root,
-    mountIsland: (entryIndex: number) =>
-      mountIsland({ root, controller, entryIndex, deliveries }),
-    statuses: () => buttons.map((button) => button.dataset.status),
+    subscribeProbe: (entryIndex: number) =>
+      subscribeProbe({ controller, entryIndex, deliveries }),
+    unsubscribeAll: () => {
+      for (const probe of probes) {
+        probe.unsubscribe();
+      }
+    },
+    statuses: () => probes.map((probe) => probe.status()),
   };
 }
 
-async function mountIsland({
-  root,
+function subscribeProbe({
   controller,
   entryIndex,
   deliveries,
 }: {
-  root: HTMLElement;
   controller: TtsPlaybackController;
   entryIndex: number;
   deliveries: Array<{ entryIndex: number; kind: string }>;
-}): Promise<HTMLButtonElement> {
-  const island = root.appendChild(document.createElement('div'));
-
-  await act(() => {
-    mountPopupComponent({
-      popupHost: root,
-      container: island,
-      vnode: h(PlayProbe, {
-        controller,
-        entryIndex,
-        onState: (state: TtsPlaybackState) =>
-          deliveries.push({ entryIndex, kind: state.kind }),
-      }),
-    });
-  });
-
-  return island.querySelector('button')!;
-}
-
-function PlayProbe({
-  controller,
-  entryIndex,
-  onState,
-}: {
-  controller: TtsPlaybackController;
-  entryIndex: number;
-  onState: (state: TtsPlaybackState) => void;
 }) {
-  const [state, setState] = useState<TtsPlaybackState>({ kind: 'idle' });
-  useEffect(
-    () =>
-      controller.subscribe((next) => {
-        onState(next);
-        setState(next);
-      }),
-    [controller]
-  );
-
-  const status =
-    state.kind !== 'idle' && state.activeEntryIndex === entryIndex
-      ? state.kind
-      : 'idle';
-
-  return h('button', {
-    'data-status': status,
-    onClick: () => controller.toggle(entryIndex),
+  let state: TtsPlaybackState = { kind: 'idle' };
+  const unsubscribe = controller.subscribe((next) => {
+    deliveries.push({ entryIndex, kind: next.kind });
+    state = next;
   });
-}
 
-function press(button: HTMLButtonElement) {
-  return act(() => {
-    button.click();
-  });
-}
-
-function flush() {
-  return advance(0);
-}
-
-function advance(ms: number) {
-  return act(async () => {
-    await vi.advanceTimersByTimeAsync(ms);
-  });
+  return {
+    status: () =>
+      state.kind !== 'idle' && state.activeEntryIndex === entryIndex
+        ? state.kind
+        : 'idle',
+    unsubscribe,
+  };
 }
 
 function deferred<T>() {
@@ -584,4 +487,8 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+function flush() {
+  return vi.advanceTimersByTimeAsync(0);
 }

--- a/src/content/tts-playback-controller.test.ts
+++ b/src/content/tts-playback-controller.test.ts
@@ -1,0 +1,587 @@
+import { h } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
+import { act } from 'preact/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  MoraTimingData,
+  TtsClip,
+  TtsClipRequest,
+} from '../common/tts/tts-request';
+
+import { mountPopupComponent, unmountPopupComponents } from './popup/mount';
+import type { TtsEntry, TtsPlaybackState } from './tts-playback-controller';
+import { TtsPlaybackController } from './tts-playback-controller';
+import { preparePlayback } from './tts/audio-clip-player';
+import type { FetchClip, PlayClip, StartInfo } from './tts/tts-player';
+
+/**
+ * @vitest-environment jsdom
+ */
+
+vi.mock('./tts/audio-clip-player', () => ({
+  preparePlayback: vi.fn<() => void>(),
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(preparePlayback).mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  document.body.replaceChildren();
+});
+
+describe('TtsPlaybackController', () => {
+  it('fetches and marks only the entry it is playing', async () => {
+    const { controller, fetches, buttons, statuses } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await flush();
+
+    expect(fetches).toEqual([]);
+
+    await press(buttons[1]);
+
+    expect(statuses()).toEqual(['idle', 'loading']);
+
+    await flush();
+
+    expect(statuses()).toEqual(['idle', 'playing']);
+    expect(fetches.map((fetch) => fetch.request)).toEqual(entryB.requests);
+    expect(controller.state).toMatchObject({
+      kind: 'playing',
+      activeEntryIndex: 1,
+      readingIndex: 0,
+    });
+  });
+
+  it('stops the playing entry when another entry starts', async () => {
+    const { buttons, statuses, playbacks } = await setUp([entryA, entryB]);
+
+    await press(buttons[0]);
+    await flush();
+    await press(buttons[1]);
+    await flush();
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(statuses()).toEqual(['idle', 'playing']);
+  });
+
+  it('starts the pressed entry while another entry is still loading', async () => {
+    const { controller, buttons, fetches, playbacks, statuses } = await setUp(
+      [entryA, entryB],
+      { deferFetch: true }
+    );
+
+    await press(buttons[0]);
+    await press(buttons[1]);
+
+    expect(fetches[0].signal.aborted).toBe(true);
+    expect(fetches[1].request).toEqual(entryB.requests[0]);
+    expect(statuses()).toEqual(['idle', 'loading']);
+
+    fetches[1].resolve();
+    await flush();
+
+    expect(playbacks).toHaveLength(1);
+    expect(statuses()).toEqual(['idle', 'playing']);
+    expect(controller.state).toMatchObject({
+      kind: 'playing',
+      activeEntryIndex: 1,
+    });
+  });
+
+  it('stops the playing entry when its own button is pressed again', async () => {
+    const { controller, buttons, statuses, playbacks } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await press(buttons[0]);
+    await flush();
+    await press(buttons[0]);
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(statuses()).toEqual(['idle', 'idle']);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('stops a loading entry when its own button is pressed again', async () => {
+    const { controller, buttons, fetches, playbacks } = await setUp(
+      [entryA, entryB],
+      { deferFetch: true }
+    );
+
+    await press(buttons[0]);
+    await press(buttons[0]);
+
+    expect(fetches[0].signal.aborted).toBe(true);
+    expect(playbacks).toEqual([]);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('plays the entry again when it is pressed while the error shows', async () => {
+    let attempts = 0;
+    const { buttons, fetches, statuses } = await setUp([entryA, entryB], {
+      failFor: () => ++attempts === 1,
+    });
+
+    await press(buttons[1]);
+    await flush();
+
+    expect(statuses()).toEqual(['idle', 'error']);
+
+    await press(buttons[1]);
+    await flush();
+
+    expect(fetches).toHaveLength(2);
+    expect(statuses()).toEqual(['idle', 'playing']);
+  });
+
+  it('reports that audio has started once the first reading plays', async () => {
+    const { controller, buttons, playbacks } = await setUp([
+      { id: 4, requests: twoReadings },
+      entryB,
+    ]);
+    const loadingStates: Array<boolean> = [];
+    controller.subscribe((state) => {
+      if (state.kind === 'loading') {
+        loadingStates.push(state.audioStarted);
+      }
+    });
+
+    await press(buttons[0]);
+    await flush();
+
+    expect(loadingStates).toEqual([false]);
+
+    playbacks[0].end();
+    await flush();
+
+    expect(loadingStates).toEqual([false, true]);
+  });
+
+  it('still attempts playback when preparing the audio context throws', async () => {
+    const { buttons, statuses } = await setUp([entryA, entryB]);
+    const warnings = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(preparePlayback).mockImplementationOnce(() => {
+      throw new Error('no audio context');
+    });
+
+    await press(buttons[0]);
+    await flush();
+
+    expect(warnings).toHaveBeenCalled();
+    expect(statuses()).toEqual(['playing', 'idle']);
+
+    await press(buttons[1]);
+    await flush();
+
+    expect(statuses()).toEqual(['idle', 'playing']);
+  });
+
+  it('keeps playing when the entries are set again with the same keys', async () => {
+    const { controller, buttons, statuses } = await setUp([entryA, entryB]);
+
+    await press(buttons[1]);
+    await flush();
+
+    await act(() => {
+      controller.setEntries([{ ...entryA }, { ...entryB }]);
+    });
+
+    expect(statuses()).toEqual(['idle', 'playing']);
+  });
+
+  it('keeps playing when the entry it is playing moves to another index', async () => {
+    const { controller, buttons, statuses, playbacks } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await press(buttons[1]);
+    await flush();
+
+    await act(() => {
+      controller.setEntries([entryB]);
+    });
+
+    expect(playbacks[0].signal.aborted).toBe(false);
+    expect(statuses()).toEqual(['playing', 'idle']);
+    expect(controller.state).toMatchObject({
+      kind: 'playing',
+      activeEntryIndex: 0,
+    });
+  });
+
+  it('stops when the audio of the entry it is playing changes', async () => {
+    const { controller, buttons, statuses, playbacks } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await press(buttons[1]);
+    await flush();
+
+    await act(() => {
+      controller.setEntries([entryA, { id: entryB.id, requests: twoReadings }]);
+    });
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(statuses()).toEqual(['idle', 'idle']);
+  });
+
+  it('stops when the entry it is playing disappears', async () => {
+    const { controller, buttons, statuses, playbacks } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await press(buttons[1]);
+    await flush();
+
+    await act(() => {
+      controller.setEntries([]);
+    });
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(statuses()).toEqual(['idle', 'idle']);
+  });
+
+  it('fetches the clips again when an entry is played after it finished', async () => {
+    const { buttons, fetches, playbacks, statuses } = await setUp([
+      { id: 4, requests: twoReadings },
+      entryB,
+    ]);
+
+    await press(buttons[0]);
+    await flush();
+    playbacks[0].end();
+    await flush();
+    playbacks[1].end();
+    await flush();
+
+    expect(fetches).toHaveLength(2);
+    expect(statuses()).toEqual(['idle', 'idle']);
+
+    await press(buttons[0]);
+    await flush();
+
+    expect(fetches).toHaveLength(4);
+    expect(statuses()).toEqual(['playing', 'idle']);
+  });
+
+  it('shows the current state on an island that mounts while a reading plays', async () => {
+    const { buttons, mountIsland } = await setUp([entryA, entryB]);
+
+    await press(buttons[1]);
+    await flush();
+    const late = await mountIsland(1);
+
+    expect(late.dataset.status).toBe('playing');
+  });
+
+  it('stops notifying an island that was unmounted', async () => {
+    const { controller, root, deliveries } = await setUp([entryA, entryB]);
+
+    expect(deliveries).toEqual([
+      { entryIndex: 0, kind: 'idle' },
+      { entryIndex: 1, kind: 'idle' },
+    ]);
+
+    unmountPopupComponents(root);
+    controller.toggle(0);
+    await flush();
+
+    expect(deliveries).toHaveLength(2);
+  });
+
+  it('keeps playing when a listener throws', async () => {
+    const { controller, buttons, statuses } = await setUp([entryA, entryB]);
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const seen: Array<string> = [];
+    controller.subscribe(() => {
+      throw new Error('listener failed');
+    });
+    controller.subscribe((state) => seen.push(state.kind));
+
+    await press(buttons[0]);
+    await flush();
+
+    expect(statuses()).toEqual(['playing', 'idle']);
+    expect(seen).toEqual(['idle', 'loading', 'playing']);
+    expect(errors).toHaveBeenCalled();
+  });
+
+  it('stops when a stop arrives while it starts an entry', async () => {
+    const { controller, buttons, fetches, playbacks, statuses } = await setUp(
+      [entryA, entryB],
+      { deferFetch: true }
+    );
+
+    await press(buttons[0]);
+
+    expect(statuses()).toEqual(['loading', 'idle']);
+
+    await act(() => {
+      controller.stop();
+    });
+    await flush();
+
+    expect(fetches[0].signal.aborted).toBe(true);
+    expect(playbacks).toEqual([]);
+    expect(statuses()).toEqual(['idle', 'idle']);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('prepares audio playback synchronously on start, and not on stop', async () => {
+    const { controller } = await setUp([entryA, entryB]);
+
+    expect(preparePlayback).not.toHaveBeenCalled();
+
+    // Called synchronously by `toggle`, not after an await: WebKit ignores a
+    // resume() that lands once the click is off the stack.
+    controller.toggle(0);
+    expect(preparePlayback).toHaveBeenCalledTimes(1);
+
+    await flush();
+    await act(() => {
+      controller.toggle(0);
+    });
+
+    expect(preparePlayback).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops playback on stop()', async () => {
+    const { controller, buttons, statuses, playbacks } = await setUp([
+      entryA,
+      entryB,
+    ]);
+
+    await press(buttons[0]);
+    await flush();
+
+    await act(() => {
+      controller.stop();
+    });
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(statuses()).toEqual(['idle', 'idle']);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('carries the exact moraTiming object and startedAt through to the playing state', async () => {
+    const moraTiming: MoraTimingData = {
+      charTimingsMs: [0, 120, 240],
+      totalDurationMs: 360,
+    };
+    const clip: TtsClip = { bytes: new Uint8Array([1]), moraTiming };
+
+    const controller = new TtsPlaybackController({
+      fetchClip: () => Promise.resolve(clip),
+      playClip: () => ({
+        started: Promise.resolve({ startedAt: 123 }),
+        ended: new Promise<void>(() => {}),
+      }),
+    });
+    controller.setEntries([entryA]);
+
+    await act(() => {
+      controller.toggle(0);
+    });
+    await flush();
+
+    expect(controller.state).toMatchObject({ kind: 'playing', startedAt: 123 });
+    const playing = controller.state;
+    expect(playing.kind === 'playing' ? playing.moraTiming : undefined).toBe(
+      moraTiming
+    );
+  });
+});
+
+const entryA: TtsEntry = {
+  id: 1,
+  requests: [{ kanji: '入る', reading: 'はいる', pitchAccentPos: 1 }],
+};
+const entryB: TtsEntry = {
+  id: 2,
+  requests: [{ kanji: '猫', reading: 'ねこ' }],
+};
+const twoReadings: Array<TtsClipRequest> = [
+  { kanji: '日', reading: 'ひ' },
+  { kanji: '日', reading: 'にち' },
+];
+
+type Behavior = {
+  deferFetch?: boolean;
+  failFor?: (request: TtsClipRequest) => boolean;
+};
+
+type FetchCall = {
+  request: TtsClipRequest;
+  signal: AbortSignal;
+  clip: TtsClip;
+  resolve: () => void;
+};
+
+type PlaybackCall = { clip: TtsClip; signal: AbortSignal; end: () => void };
+
+async function setUp(
+  entries: ReadonlyArray<TtsEntry>,
+  behavior: Behavior = {}
+) {
+  const fetches: Array<FetchCall> = [];
+  const playbacks: Array<PlaybackCall> = [];
+
+  const fetchClip: FetchClip = (request, signal) => {
+    const result = deferred<TtsClip>();
+    const clip: TtsClip = { bytes: new Uint8Array([fetches.length]) };
+    const reject = () => result.reject(new Error('fetch failed'));
+    fetches.push({
+      request,
+      signal,
+      clip,
+      resolve: () => result.resolve(clip),
+    });
+
+    signal.addEventListener('abort', reject, { once: true });
+    if (behavior.failFor?.(request)) {
+      reject();
+    } else if (!behavior.deferFetch) {
+      result.resolve(clip);
+    }
+
+    return result.promise;
+  };
+
+  const playClip: PlayClip = (clip, signal) => {
+    const started = deferred<StartInfo>();
+    const ended = deferred<void>();
+    playbacks.push({ clip, signal, end: () => ended.resolve() });
+
+    signal.addEventListener(
+      'abort',
+      () => {
+        started.reject(new Error('aborted'));
+        ended.reject(new Error('aborted'));
+      },
+      { once: true }
+    );
+    started.resolve({ startedAt: playbacks.length * 100 });
+
+    return { started: started.promise, ended: ended.promise };
+  };
+
+  const controller = new TtsPlaybackController({ fetchClip, playClip });
+  controller.setEntries(entries);
+
+  const root = document.createElement('div');
+  document.body.append(root);
+  const deliveries: Array<{ entryIndex: number; kind: string }> = [];
+  const buttons = [
+    await mountIsland({ root, controller, entryIndex: 0, deliveries }),
+    await mountIsland({ root, controller, entryIndex: 1, deliveries }),
+  ];
+
+  return {
+    controller,
+    fetches,
+    playbacks,
+    buttons,
+    deliveries,
+    root,
+    mountIsland: (entryIndex: number) =>
+      mountIsland({ root, controller, entryIndex, deliveries }),
+    statuses: () => buttons.map((button) => button.dataset.status),
+  };
+}
+
+async function mountIsland({
+  root,
+  controller,
+  entryIndex,
+  deliveries,
+}: {
+  root: HTMLElement;
+  controller: TtsPlaybackController;
+  entryIndex: number;
+  deliveries: Array<{ entryIndex: number; kind: string }>;
+}): Promise<HTMLButtonElement> {
+  const island = root.appendChild(document.createElement('div'));
+
+  await act(() => {
+    mountPopupComponent({
+      popupHost: root,
+      container: island,
+      vnode: h(PlayProbe, {
+        controller,
+        entryIndex,
+        onState: (state: TtsPlaybackState) =>
+          deliveries.push({ entryIndex, kind: state.kind }),
+      }),
+    });
+  });
+
+  return island.querySelector('button')!;
+}
+
+function PlayProbe({
+  controller,
+  entryIndex,
+  onState,
+}: {
+  controller: TtsPlaybackController;
+  entryIndex: number;
+  onState: (state: TtsPlaybackState) => void;
+}) {
+  const [state, setState] = useState<TtsPlaybackState>({ kind: 'idle' });
+  useEffect(
+    () =>
+      controller.subscribe((next) => {
+        onState(next);
+        setState(next);
+      }),
+    [controller]
+  );
+
+  const status =
+    state.kind !== 'idle' && state.activeEntryIndex === entryIndex
+      ? state.kind
+      : 'idle';
+
+  return h('button', {
+    'data-status': status,
+    onClick: () => controller.toggle(entryIndex),
+  });
+}
+
+function press(button: HTMLButtonElement) {
+  return act(() => {
+    button.click();
+  });
+}
+
+function flush() {
+  return advance(0);
+}
+
+function advance(ms: number) {
+  return act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/content/tts-playback-controller.ts
+++ b/src/content/tts-playback-controller.ts
@@ -1,0 +1,281 @@
+import type { MoraTimingData, TtsClipRequest } from '../common/tts/tts-request';
+import { buildTtsFilename } from '../common/tts/tts-request';
+
+import { preparePlayback } from './tts/audio-clip-player';
+import type { TtsPlayerOptions } from './tts/tts-player';
+import { TtsPlayer } from './tts/tts-player';
+
+export type TtsEntry = { id: number; requests: Array<TtsClipRequest> };
+
+export type TtsPlaybackState =
+  | { kind: 'idle' }
+  | {
+      kind: 'loading';
+      activeEntryIndex: number;
+      readingIndex: number;
+      audioStarted: boolean;
+    }
+  | {
+      kind: 'playing';
+      activeEntryIndex: number;
+      readingIndex: number;
+      startedAt: number;
+      moraTiming?: MoraTimingData;
+    }
+  | { kind: 'error'; activeEntryIndex: number };
+
+type TtsPlaybackListener = (state: TtsPlaybackState) => void;
+
+export type TtsPlaybackHandle = Pick<
+  TtsPlaybackController,
+  'subscribe' | 'toggle' | 'state'
+>;
+
+export class TtsPlaybackController {
+  #player: TtsPlayer;
+  #entries: ReadonlyArray<TtsEntry> = [];
+  #activeEntry: { index: number; key: string } | undefined;
+  #audioStarted = false;
+  #actions: Array<() => void> = [];
+  #draining = false;
+  #state: TtsPlaybackState = { kind: 'idle' };
+  #listeners = new Set<TtsPlaybackListener>();
+
+  constructor(options: TtsPlayerOptions) {
+    this.#player = new TtsPlayer(options);
+    this.#player.subscribe(this.#onPlayerState);
+  }
+
+  get state(): TtsPlaybackState {
+    return this.#state;
+  }
+
+  subscribe(listener: TtsPlaybackListener): () => void {
+    this.#listeners.add(listener);
+    notify(listener, this.#state);
+
+    return () => this.#listeners.delete(listener);
+  }
+
+  setEntries(entries: ReadonlyArray<TtsEntry>) {
+    this.#enqueue(() => this.#applySetEntries(entries));
+  }
+
+  toggle(entryIndex: number) {
+    this.#enqueue(() => this.#applyToggle(entryIndex));
+  }
+
+  stop() {
+    this.#enqueue(() => this.#applyStop());
+  }
+
+  #enqueue(action: () => void) {
+    this.#actions.push(action);
+    this.#drainWhenIdle();
+  }
+
+  #onPlayerState = () => {
+    if (this.#player.state.kind === 'playing') {
+      this.#audioStarted = true;
+    }
+    this.#drainWhenIdle();
+  };
+
+  #drainWhenIdle() {
+    // The drain that already runs picks this change up and publishes only at
+    // quiescence.
+    if (this.#draining) {
+      return;
+    }
+
+    this.#draining = true;
+    try {
+      this.#drain();
+    } finally {
+      this.#draining = false;
+    }
+  }
+
+  #drain() {
+    let delivery:
+      | { state: TtsPlaybackState; recipients: Array<TtsPlaybackListener> }
+      | undefined;
+
+    for (;;) {
+      const action = this.#actions.shift();
+      if (action) {
+        this.#runAction(action);
+        continue;
+      }
+
+      const state = this.#currentState();
+      if (state.kind === 'idle') {
+        this.#activeEntry = undefined;
+      }
+      if (!sameState(state, this.#state)) {
+        this.#state = state;
+        delivery = { state, recipients: [...this.#listeners] };
+      }
+
+      const recipient = delivery?.recipients.shift();
+      if (!delivery || !recipient) {
+        return;
+      }
+      if (this.#listeners.has(recipient)) {
+        notify(recipient, delivery.state);
+      }
+    }
+  }
+
+  #runAction(action: () => void) {
+    try {
+      action();
+    } catch (error) {
+      console.error('[10ten-ja-reader] Reading playback action failed', error);
+      // Leave nothing half-started: the queue behind us still has to drain,
+      // and a session we cannot finish must not keep the UI showing Stop.
+      this.#applyStop();
+    }
+  }
+
+  #currentState(): TtsPlaybackState {
+    const playerState = this.#player.state;
+    const active = this.#activeEntry;
+    if (playerState.kind === 'idle' || !active) {
+      return { kind: 'idle' };
+    }
+
+    const activeEntryIndex = active.index;
+    switch (playerState.kind) {
+      case 'loading':
+        return {
+          kind: 'loading',
+          activeEntryIndex,
+          readingIndex: playerState.readingIndex,
+          audioStarted: this.#audioStarted,
+        };
+
+      case 'playing':
+        return {
+          kind: 'playing',
+          activeEntryIndex,
+          readingIndex: playerState.readingIndex,
+          startedAt: playerState.startedAt,
+          moraTiming: playerState.moraTiming,
+        };
+
+      case 'error':
+        return { kind: 'error', activeEntryIndex };
+    }
+  }
+
+  #applySetEntries(entries: ReadonlyArray<TtsEntry>) {
+    this.#entries = entries;
+
+    const active = this.#activeEntry;
+    if (!active) {
+      return;
+    }
+
+    const stillThere = entries[active.index];
+    const index =
+      stillThere && entryKey(stillThere) === active.key
+        ? active.index
+        : entries.findIndex((entry) => entryKey(entry) === active.key);
+    if (index < 0) {
+      this.#applyStop();
+      return;
+    }
+
+    if (index !== active.index) {
+      this.#activeEntry = { ...active, index };
+    }
+  }
+
+  #applyToggle(entryIndex: number) {
+    const entry = this.#entries[entryIndex];
+    if (!entry) {
+      return;
+    }
+
+    if (this.#isRunningEntry(entryIndex)) {
+      this.#applyStop();
+      return;
+    }
+
+    try {
+      // Must run while the click is on the stack: `playClip` rejects without
+      // it, and WebKit ignores a resume() once the gesture is over. Play
+      // anyway on failure so it surfaces as an error badge, not a dead button.
+      preparePlayback();
+    } catch (error) {
+      console.warn(
+        '[10ten-ja-reader] Could not prepare reading playback',
+        error
+      );
+    }
+
+    this.#activeEntry = { index: entryIndex, key: entryKey(entry) };
+    this.#audioStarted = false;
+    this.#player.setReadings(entry.requests);
+    this.#player.playAll();
+  }
+
+  #applyStop() {
+    this.#activeEntry = undefined;
+    this.#audioStarted = false;
+    this.#player.stop();
+  }
+
+  #isRunningEntry(entryIndex: number): boolean {
+    // Test the player, not the published state: while actions drain, the
+    // published state can be older than the session the player holds.
+    const { kind } = this.#player.state;
+    return (
+      this.#activeEntry?.index === entryIndex &&
+      (kind === 'loading' || kind === 'playing')
+    );
+  }
+}
+
+function notify(listener: TtsPlaybackListener, state: TtsPlaybackState) {
+  try {
+    listener(state);
+  } catch (error) {
+    console.error('[10ten-ja-reader] Reading playback listener failed', error);
+  }
+}
+
+function sameState(a: TtsPlaybackState, b: TtsPlaybackState): boolean {
+  switch (a.kind) {
+    case 'idle':
+      return b.kind === 'idle';
+
+    case 'loading':
+      return (
+        b.kind === 'loading' &&
+        a.activeEntryIndex === b.activeEntryIndex &&
+        a.readingIndex === b.readingIndex &&
+        a.audioStarted === b.audioStarted
+      );
+
+    case 'playing':
+      return (
+        b.kind === 'playing' &&
+        a.activeEntryIndex === b.activeEntryIndex &&
+        a.readingIndex === b.readingIndex &&
+        a.startedAt === b.startedAt &&
+        a.moraTiming === b.moraTiming
+      );
+
+    case 'error':
+      return b.kind === 'error' && a.activeEntryIndex === b.activeEntryIndex;
+  }
+}
+
+function entryKey(entry: TtsEntry): string {
+  // Do not key playback on this instead of the row position. Two rows can
+  // carry the same id (several deinflection paths reaching one entry) and the
+  // same audio, so only the position tells them apart.
+  return `${entry.id}\n${entry.requests.map(buildTtsFilename).join('\n')}`;
+}

--- a/src/content/tts-playback-controller.ts
+++ b/src/content/tts-playback-controller.ts
@@ -26,6 +26,7 @@ export type TtsPlaybackState =
 
 type TtsPlaybackListener = (state: TtsPlaybackState) => void;
 
+// The part of the controller we hand to the popup.
 export type TtsPlaybackHandle = Pick<
   TtsPlaybackController,
   'subscribe' | 'toggle' | 'state'
@@ -82,8 +83,9 @@ export class TtsPlaybackController {
   };
 
   #drainWhenIdle() {
-    // The drain that already runs picks this change up and publishes only at
-    // quiescence.
+    // We are inside #drain: an action or a listener called back in. Its loop
+    // reads #actions and the player again each pass, so it sees this change.
+    // A nested drain would publish mid-action and clear #activeEntry.
     if (this.#draining) {
       return;
     }
@@ -132,8 +134,8 @@ export class TtsPlaybackController {
       action();
     } catch (error) {
       console.error('[10ten-ja-reader] Reading playback action failed', error);
-      // Leave nothing half-started: the queue behind us still has to drain,
-      // and a session we cannot finish must not keep the UI showing Stop.
+      // Do not rethrow: the rest of #actions must still run. Stop the player
+      // too, or a half-started entry leaves its button showing Stop.
       this.#applyStop();
     }
   }
@@ -206,7 +208,7 @@ export class TtsPlaybackController {
     try {
       // Must run while the click is on the stack: `playClip` rejects without
       // it, and WebKit ignores a resume() once the gesture is over. Play
-      // anyway on failure so it surfaces as an error badge, not a dead button.
+      // anyway on failure so the user sees an error badge, not a dead button.
       preparePlayback();
     } catch (error) {
       console.warn(
@@ -228,8 +230,8 @@ export class TtsPlaybackController {
   }
 
   #isRunningEntry(entryIndex: number): boolean {
-    // Test the player, not the published state: while actions drain, the
-    // published state can be older than the session the player holds.
+    // Read the player, not #state. #drain updates #state only once #actions is
+    // empty, so during a drain #state can lag behind the player.
     const { kind } = this.#player.state;
     return (
       this.#activeEntry?.index === entryIndex &&
@@ -274,8 +276,8 @@ function sameState(a: TtsPlaybackState, b: TtsPlaybackState): boolean {
 }
 
 function entryKey(entry: TtsEntry): string {
-  // Do not key playback on this instead of the row position. Two rows can
-  // carry the same id (several deinflection paths reaching one entry) and the
-  // same audio, so only the position tells them apart.
+  // This key is not unique, so #activeEntry must keep the row index too. Two
+  // rows can have the same id (one entry reached by several deinflection
+  // paths) and the same audio. Only the row index tells them apart.
   return `${entry.id}\n${entry.requests.map(buildTtsFilename).join('\n')}`;
 }

--- a/src/content/tts/tts-params.test.ts
+++ b/src/content/tts/tts-params.test.ts
@@ -2,7 +2,28 @@ import { describe, expect, it } from 'vitest';
 
 import type { WordResult } from '../../background/search-result';
 
-import { resolveTtsParams } from './tts-params';
+import { resolveNameTtsParams, resolveTtsParams } from './tts-params';
+
+describe('resolveNameTtsParams', () => {
+  it('uses the first kanji form for every displayed reading', () => {
+    expect(
+      resolveNameTtsParams({
+        k: ['秋篠宮', '秋篠の宮'],
+        r: ['あきしのみや', 'あきしののみや'],
+      })
+    ).toEqual([
+      { kanji: '秋篠宮', reading: 'あきしのみや' },
+      { kanji: '秋篠宮', reading: 'あきしののみや' },
+    ]);
+  });
+
+  it('uses reading-only requests for kana-only names', () => {
+    expect(resolveNameTtsParams({ r: ['ノコノコ', 'のこ'] })).toEqual([
+      { reading: 'ノコノコ' },
+      { reading: 'のこ' },
+    ]);
+  });
+});
 
 describe('resolveTtsParams', () => {
   it('returns the displayed kana verbatim with no kanji for a kana-only entry', () => {

--- a/src/content/tts/tts-params.ts
+++ b/src/content/tts/tts-params.ts
@@ -1,4 +1,4 @@
-import type { WordResult } from '../../background/search-result';
+import type { NameResult, WordResult } from '../../background/search-result';
 import { getDisplayedKana } from '../../common/displayed-kana';
 import type { TtsClipRequest } from '../../common/tts/tts-request';
 
@@ -6,6 +6,13 @@ export function resolveTtsParams(entry: WordResult): Array<TtsClipRequest> {
   return getDisplayedKana(entry).map((kana) =>
     resolveReadingParams(kana, entry.k)
   );
+}
+
+export function resolveNameTtsParams(
+  entry: Pick<NameResult, 'k' | 'r'>
+): Array<TtsClipRequest> {
+  const kanji = entry.k?.[0];
+  return entry.r.map((reading) => ({ reading, ...(kanji ? { kanji } : {}) }));
 }
 
 function resolveReadingParams(


### PR DESCRIPTION
Why: Playback state belongs to the popup, not to an individual entry button. This PR adds one popup-scoped controller that serializes reading audio, maps both word and name entries into TTS requests, and follows lookup, dictionary, configuration, and popup lifecycle changes. It exposes that state to the next UI layer but renders no controls itself.

Stack:

- [#3103 Clean up popup components when replacing the popup](https://github.com/birchill/10ten-ja-reader/pull/3103)
- [#3104 Prepare word readings for audio playback](https://github.com/birchill/10ten-ja-reader/pull/3104)
- [#3105 Fetch and play reading audio across browsers](https://github.com/birchill/10ten-ja-reader/pull/3105)
- [#3106 Coordinate reading playback within a popup](https://github.com/birchill/10ten-ja-reader/pull/3106) (this PR)
- [#3129 Add play buttons for word and name readings](https://github.com/birchill/10ten-ja-reader/pull/3129)
- [#3107 Highlight readings as they are spoken](https://github.com/birchill/10ten-ja-reader/pull/3107)
- [#3108 Add settings and shortcuts for reading audio](https://github.com/birchill/10ten-ja-reader/pull/3108)
