### PR TITLE
Clear stale child frames on root navigation

### DIFF
--- a/src/background/all-tab-manager.test.ts
+++ b/src/background/all-tab-manager.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Runtime } from 'webextension-polyfill';
+
+import type { ContentConfigParams } from '../common/content-config-params';
+
+import AllTabManager from './all-tab-manager';
+
+type MessageListener = (
+  request: unknown,
+  sender: Runtime.MessageSender
+) => unknown;
+
+const { browserMock, messageListeners } = vi.hoisted(() => {
+  const messageListeners: Array<MessageListener> = [];
+  const browserMock = {
+    runtime: {
+      onMessage: {
+        addListener: vi.fn<(listener: MessageListener) => void>((listener) => {
+          messageListeners.push(listener);
+        }),
+      },
+    },
+    storage: {
+      local: { get: vi.fn<() => Promise<object>>(() => Promise.resolve({})) },
+    },
+    tabs: {
+      onActivated: {
+        addListener:
+          vi.fn<(listener: (details: { tabId: number }) => unknown) => void>(),
+      },
+      query: vi.fn<() => Promise<Array<never>>>(() => Promise.resolve([])),
+      sendMessage: vi.fn<() => Promise<string>>(() => Promise.resolve('ok')),
+    },
+  };
+
+  return { browserMock, messageListeners };
+});
+
+vi.mock('@birchill/bugsnag-zero', () => ({
+  default: {
+    leaveBreadcrumb: vi.fn<(...args: Array<unknown>) => void>(),
+    notify: vi.fn<(...args: Array<unknown>) => void>(),
+  },
+}));
+vi.mock('webextension-polyfill', () => ({ default: browserMock }));
+
+describe('AllTabManager', () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('drops stale child frames when the root frame navigates', async () => {
+    vi.useFakeTimers();
+
+    const manager = new AllTabManager();
+    await manager.init({} as ContentConfigParams);
+
+    const onMessage = messageListeners[0];
+    expect(onMessage).toBeDefined();
+
+    const sendEnabled = (frameId: number, src: string) =>
+      onMessage({ type: 'enabled', src }, {
+        frameId,
+        tab: { id: 1 },
+      } as Runtime.MessageSender);
+
+    await sendEnabled(0, 'https://example.com/old');
+    await sendEnabled(2, 'https://example.com/old-frame');
+    expect(manager.getInitialFrameSrc({ tabId: 1, frameId: 2 })).toBe(
+      'https://example.com/old-frame'
+    );
+
+    await sendEnabled(0, 'https://example.com/new');
+
+    expect(manager.getInitialFrameSrc({ tabId: 1, frameId: 0 })).toBe(
+      'https://example.com/new'
+    );
+    expect(
+      manager.getInitialFrameSrc({ tabId: 1, frameId: 2 })
+    ).toBeUndefined();
+  });
+});

--- a/src/background/all-tab-manager.ts
+++ b/src/background/all-tab-manager.ts
@@ -343,12 +343,12 @@ export default class AllTabManager implements TabManager {
   }) {
     if (tabId in this.#tabs) {
       const tab = this.#tabs[tabId];
-      if (frameId === 0) {
-        tab.src = src;
-      }
       // If we have navigated the root frame, blow away all the child frames
       if (frameId === 0 && tab.src !== src && tab.src !== '') {
         tab.frames = {};
+      }
+      if (frameId === 0) {
+        tab.src = src;
       }
     } else {
       this.#tabs[tabId] = { src: frameId === 0 ? src : '', frames: {} };


### PR DESCRIPTION
Why: Navigating the root frame could leave stale child-frame records from the previous page in the tab manager.

This clears child-frame state before recording a changed root URL.

Stack:
- #3116
- #3117
- **This PR**

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>