### PR TITLE
fix: handle lookup puck taps on recent iOS 26 releases

### DIFF
--- a/.changeset/gentle-pucks-tap.md
+++ b/.changeset/gentle-pucks-tap.md
@@ -1,0 +1,6 @@
+---
+'10ten-ja-reader': patch
+---
+
+(Safari) Fixed tap and double-tap handling for the lookup puck on recent iOS 26
+releases (#3020).

--- a/src/content/puck.test.ts
+++ b/src/content/puck.test.ts
@@ -20,7 +20,7 @@ declare global {
   var chrome: any;
 }
 
-describe('LookupPuck tap handling on iOS', () => {
+describe('LookupPuck', () => {
   let LookupPuck: typeof LookupPuckClass;
   let LookupPuckId: string;
   let previousBrowserObject: any;
@@ -89,14 +89,11 @@ describe('LookupPuck tap handling on iOS', () => {
     vi.useRealTimers();
   });
 
-  it('cancels compatibility mouse events from a handled pointer tap', () => {
-    dispatchPointerTap(1);
-    const { mouseDown, mouseUp } = dispatchMouseTap(1);
+  it('toggles lookups with a single tap', () => {
+    tapPuck();
 
     vi.advanceTimersByTime(300);
 
-    expect(mouseDown.defaultPrevented).toBe(true);
-    expect(mouseUp.defaultPrevented).toBe(true);
     expect(subject.getEnabledState()).toBe('inactive');
     expect(subject.getTargetOrientation()).toEqual({
       readingDirection: 'horizontal',
@@ -104,9 +101,8 @@ describe('LookupPuck tap handling on iOS', () => {
     });
   });
 
-  it('uses mouse events when iOS swallows the second pointer tap', () => {
-    dispatchPointerTap(1);
-    dispatchMouseTap(2);
+  it('moves the moon to the opposite side with a double tap', () => {
+    doubleTapPuck();
 
     expect(subject.getEnabledState()).toBe('active');
     expect(subject.getTargetOrientation()).toEqual({
@@ -115,39 +111,40 @@ describe('LookupPuck tap handling on iOS', () => {
     });
   });
 
-  function dispatchPointerTap(pointerId: number) {
+  function tapPuck() {
+    dispatchPointerTap();
+    dispatchMouseTap(1);
+  }
+
+  function doubleTapPuck() {
+    tapPuck();
+    dispatchMouseTap(2);
+  }
+
+  function dispatchPointerTap() {
     puckElement.dispatchEvent(
       new PointerEvent('pointerdown', {
         bubbles: true,
         cancelable: true,
-        pointerId,
+        pointerId: 1,
       })
     );
     window.dispatchEvent(
       new PointerEvent('pointerup', {
         bubbles: true,
         cancelable: true,
-        pointerId,
+        pointerId: 1,
       })
     );
   }
 
   function dispatchMouseTap(detail: number) {
-    const mouseDown = new MouseEvent('mousedown', {
-      bubbles: true,
-      cancelable: true,
-      detail,
-    });
-    puckElement.dispatchEvent(mouseDown);
-
-    const mouseUp = new MouseEvent('mouseup', {
-      bubbles: true,
-      cancelable: true,
-      detail,
-    });
-    puckElement.dispatchEvent(mouseUp);
-
-    return { mouseDown, mouseUp };
+    puckElement.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, cancelable: true, detail })
+    );
+    puckElement.dispatchEvent(
+      new MouseEvent('mouseup', { bubbles: true, cancelable: true, detail })
+    );
   }
 });
 

--- a/src/content/puck.test.ts
+++ b/src/content/puck.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+import type { LookupPuck as LookupPuckClass } from './puck';
+import type { SafeAreaProvider } from './safe-area-provider';
+
+vi.mock('../utils/ua-utils', () => ({ isIOS: () => true }));
+
+declare global {
+  var browser: any;
+  var chrome: any;
+}
+
+describe('LookupPuck tap handling on iOS', () => {
+  let LookupPuck: typeof LookupPuckClass;
+  let LookupPuckId: string;
+  let previousBrowserObject: any;
+  let previousChromeObject: any;
+  let previousPointerEvent: typeof PointerEvent;
+
+  let subject: LookupPuckClass;
+  let puckElement: HTMLDivElement;
+
+  beforeAll(async () => {
+    previousPointerEvent = globalThis.PointerEvent;
+    globalThis.PointerEvent = class extends MouseEvent {
+      readonly pointerId: number;
+
+      constructor(type: string, init: PointerEventInit = {}) {
+        super(type, init);
+        this.pointerId = init.pointerId ?? 0;
+      }
+    } as typeof PointerEvent;
+
+    previousChromeObject = globalThis.chrome;
+    globalThis.chrome = { runtime: { id: 'test' } };
+
+    previousBrowserObject = globalThis.browser;
+    globalThis.browser = {
+      storage: { local: { get: async () => ({}), set: async () => {} } },
+    };
+
+    ({ LookupPuck, LookupPuckId } = await import('./puck'));
+  });
+
+  afterAll(() => {
+    globalThis.PointerEvent = previousPointerEvent;
+    globalThis.browser = previousBrowserObject;
+    globalThis.chrome = previousChromeObject;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    subject = new LookupPuck({
+      initialPosition: {
+        x: 0,
+        y: 0,
+        orientation: { readingDirection: 'horizontal', moonSide: 'above' },
+      },
+      safeAreaProvider: makeSafeAreaProvider(),
+      onLookupDisabled: () => {},
+      onPuckStateChanged: () => {},
+      handedness: 'unset',
+      toolbarIcon: 'default',
+      theme: 'blue',
+      fontSize: 'normal',
+      fontFace: 'system',
+    });
+    subject.render();
+    subject.setEnabledState('active');
+
+    const container = document.getElementById(LookupPuckId);
+    puckElement = container!.shadowRoot!.querySelector('.puck')!;
+    puckElement.setPointerCapture = vi.fn<(pointerId: number) => void>();
+  });
+
+  afterEach(() => {
+    subject.unmount();
+    vi.useRealTimers();
+  });
+
+  it('cancels compatibility mouse events from a handled pointer tap', () => {
+    dispatchPointerTap(1);
+    const { mouseDown, mouseUp } = dispatchMouseTap(1);
+
+    vi.advanceTimersByTime(300);
+
+    expect(mouseDown.defaultPrevented).toBe(true);
+    expect(mouseUp.defaultPrevented).toBe(true);
+    expect(subject.getEnabledState()).toBe('inactive');
+    expect(subject.getTargetOrientation()).toEqual({
+      readingDirection: 'horizontal',
+      moonSide: 'above',
+    });
+  });
+
+  it('uses mouse events when iOS swallows the second pointer tap', () => {
+    dispatchPointerTap(1);
+    dispatchMouseTap(2);
+
+    expect(subject.getEnabledState()).toBe('active');
+    expect(subject.getTargetOrientation()).toEqual({
+      readingDirection: 'horizontal',
+      moonSide: 'below',
+    });
+  });
+
+  function dispatchPointerTap(pointerId: number) {
+    puckElement.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        pointerId,
+      })
+    );
+    window.dispatchEvent(
+      new PointerEvent('pointerup', {
+        bubbles: true,
+        cancelable: true,
+        pointerId,
+      })
+    );
+  }
+
+  function dispatchMouseTap(detail: number) {
+    const mouseDown = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+      detail,
+    });
+    puckElement.dispatchEvent(mouseDown);
+
+    const mouseUp = new MouseEvent('mouseup', {
+      bubbles: true,
+      cancelable: true,
+      detail,
+    });
+    puckElement.dispatchEvent(mouseUp);
+
+    return { mouseDown, mouseUp };
+  }
+});
+
+function makeSafeAreaProvider(): SafeAreaProvider {
+  return {
+    getSafeArea: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as SafeAreaProvider;
+}

--- a/src/content/puck.ts
+++ b/src/content/puck.ts
@@ -916,8 +916,10 @@ export class LookupPuck {
       return;
     }
 
+    event.preventDefault();
+
     // We only care about detecting the start of a second tap
-    if (this.#clickState.kind !== 'firstclick') {
+    if (event.detail < 2 || this.#clickState.kind !== 'firstclick') {
       return;
     }
 
@@ -934,8 +936,6 @@ export class LookupPuck {
         }
       }, clickAndHoldHysteresis),
     };
-
-    event.preventDefault();
 
     this.#beginDelayedClickAndHoldAnimation();
 
@@ -967,13 +967,14 @@ export class LookupPuck {
       return;
     }
 
+    event.preventDefault();
+
     // We only care about detecting the end of the second tap in a double-tap
     // gesture.
-    if (this.#clickState.kind !== 'secondpointerdown') {
+    if (event.detail < 2 || this.#clickState.kind !== 'secondpointerdown') {
       return;
     }
 
-    event.preventDefault();
     event.stopPropagation();
 
     this.#stopDraggingPuck();

--- a/src/content/puck.ts
+++ b/src/content/puck.ts
@@ -916,6 +916,9 @@ export class LookupPuck {
       return;
     }
 
+    // Keep this before the second-tap guard. WebKit bug 313688 exposes the
+    // first tap's mouse events, whose default action can zoom the page:
+    // https://bugs.webkit.org/show_bug.cgi?id=313688
     event.preventDefault();
 
     // We only care about detecting the start of a second tap


### PR DESCRIPTION
Why: The lookup puck should distinguish single taps from double taps on affected iOS 26 releases without letting Safari zoom the page. [WebKit bug 313688](https://bugs.webkit.org/show_bug.cgi?id=313688) causes iOS to emit compatibility mouse events even when `pointerdown` is prevented, so the first tap enters the mouse-only second-tap fallback. The upstream fix is included in [Safari 27](https://webkit.org/blog/17967/news-from-wwdc26-webkit-in-safari-27-beta/), but affected Safari versions still need this workaround.

Closes #3020.

Testing:

- [ ] iOS 26: a single puck tap toggles lookup without changing the moon side
- [ ] iOS 26: a double tap flips the moon once without zooming the page

See fixed version:

https://github.com/user-attachments/assets/bb2fbc50-0a48-45db-860f-17028e0ad35e
