### PR TITLE
Fix changelog release links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based roughly on [Keep a Changelog](https://keepachangelog.com/en/
 This project does _not_ adhere to semantic versioning—it's a consumer
 app.
 
-## [Unreleased]
-
 ## [1.28.0] - 2026-09-02
 
 - Avoid looking up text when the cursor is far off the end of the line ([#2813](https://github.com/birchill/10ten-ja-reader/issues/2813)).
@@ -1352,7 +1350,7 @@ app.
 
 - Initial version (yes, it took me four attempts to publish).
 
-[Unreleased]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.2...HEAD
+[1.28.0]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.2...v1.28.0
 [1.27.2]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.1...v1.27.2
 [1.27.1]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.0...v1.27.1
 [1.27.0]: https://github.com/birchill/10ten-ja-reader/compare/v1.26.1...v1.27.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ Pre-release checks:
   Otherwise the submission will likely be rejected from AMO.
 
 - It's also good to check that the release notes are being parsed correctly by
-  running `pnpm tsx scripts/release-notes.js`.
+  running `pnpm tsx scripts/release-notes.js <version>`.
 
 When changesets are merged to `main`, the
 [Changesets workflow](https://github.com/birchill/10ten-ja-reader/actions/workflows/changesets.yml)

--- a/scripts/postprocess-changeset-changelog.js
+++ b/scripts/postprocess-changeset-changelog.js
@@ -3,8 +3,7 @@ import * as url from 'node:url';
 
 // Normalizes the CHANGELOG.md output from `changeset version` to match this
 // repo's existing changelog format: remove Changesets' change-type section
-// headings, and keep the new release block directly after the Unreleased
-// section.
+// headings, and keep the new release block before the previous release.
 //
 // The version heading is deliberately left in its plain `## <version>` form so
 // that the Changesets action can locate the new release's section when building
@@ -21,8 +20,8 @@ const CHANGESET_SECTION_HEADINGS = new Set([
 /**
  * Rewrites the raw `changeset version` changelog into this repo's flat format:
  * strips the change-type section headings, collapses the release notes into a
- * single contiguous bullet list, and positions the new release block directly
- * after the Unreleased section.
+ * single contiguous bullet list, and positions the new release block before
+ * the previous release.
  *
  * @param {{ changeLog: string; version: string }} options
  * @returns {string}
@@ -31,7 +30,7 @@ export function postprocessChangelog({ changeLog, version }) {
   const lines = changeLog
     .split(/\r\n|\r|\n/g)
     .filter((line) => !CHANGESET_SECTION_HEADINGS.has(line));
-  return `${moveReleaseBlockAfterUnreleased({ lines, version })
+  return `${moveReleaseBlockBeforePreviousRelease({ lines, version })
     .join('\n')
     .replace(/\n{3,}/g, '\n\n')
     .trimEnd()}\n`;
@@ -58,7 +57,7 @@ function main() {
   }
 }
 
-function moveReleaseBlockAfterUnreleased({ lines, version }) {
+function moveReleaseBlockBeforePreviousRelease({ lines, version }) {
   const releaseStart = lines.findIndex((line) =>
     isVersionHeading({ line, version })
   );
@@ -74,23 +73,19 @@ function moveReleaseBlockAfterUnreleased({ lines, version }) {
     ...lines.slice(0, releaseStart),
     ...lines.slice(releaseEnd),
   ];
-  const unreleasedIndex = withoutReleaseBlock.findIndex(isUnreleasedHeading);
-  if (unreleasedIndex === -1) {
+  const previousReleaseIndex = withoutReleaseBlock.findIndex(isReleaseHeading);
+  if (previousReleaseIndex === -1) {
     return lines;
   }
 
-  const nextVersionIndex = withoutReleaseBlock.findIndex(
-    (line, index) => index > unreleasedIndex && line.startsWith('## ')
-  );
-  const insertIndex =
-    nextVersionIndex === -1 ? withoutReleaseBlock.length : nextVersionIndex;
-
   return [
-    ...trimTrailingBlankLines(withoutReleaseBlock.slice(0, insertIndex)),
+    ...trimTrailingBlankLines(
+      withoutReleaseBlock.slice(0, previousReleaseIndex)
+    ),
     '',
     ...releaseBlock,
     '',
-    ...trimLeadingBlankLines(withoutReleaseBlock.slice(insertIndex)),
+    ...trimLeadingBlankLines(withoutReleaseBlock.slice(previousReleaseIndex)),
   ];
 }
 
@@ -159,8 +154,8 @@ function isVersionHeading({ line, version }) {
   return new RegExp(`^## ${escapeRegExp(version)}\\s*$`).test(line);
 }
 
-function isUnreleasedHeading(line) {
-  return /^##\s+(?:\[Unreleased\]|Unreleased)\s*$/.test(line);
+function isReleaseHeading(line) {
+  return /^##\s+\[?\d/.test(line);
 }
 
 function trimBlankLines(lines) {

--- a/scripts/postprocess-changeset-changelog.test.js
+++ b/scripts/postprocess-changeset-changelog.test.js
@@ -11,12 +11,14 @@ describe('postprocessChangelog', () => {
   it('strips the change-type heading and keeps the version heading', () => {
     const changeLog = `# Changelog
 
-## [Unreleased]
-
 ## 1.28.0
 ### Minor Changes
 
 - Only note
+
+## [1.27.3] - 2026-06-08
+
+- Earlier point
 `;
 
     const result = postprocessChangelog({ changeLog, version: '1.28.0' });
@@ -27,8 +29,6 @@ describe('postprocessChangelog', () => {
 
   it('keeps notes within a section adjacent', () => {
     const changeLog = `# Changelog
-
-## [Unreleased]
 
 ## 1.28.0
 ### Minor Changes
@@ -53,8 +53,6 @@ describe('postprocessChangelog', () => {
     // would otherwise leave a blank line where the boundary used to be.
     const changeLog = `# Changelog
 
-## [Unreleased]
-
 ## 1.29.0
 ### Minor Changes
 
@@ -63,6 +61,10 @@ describe('postprocessChangelog', () => {
 ### Patch Changes
 
 - A patch note
+
+## [1.28.0] - 2026-06-08
+
+- Earlier point
 `;
 
     const result = postprocessChangelog({ changeLog, version: '1.29.0' });
@@ -75,14 +77,16 @@ describe('postprocessChangelog', () => {
   it('preserves indented continuation lines of multi-line notes', () => {
     const changeLog = `# Changelog
 
-## [Unreleased]
-
 ## 1.29.0
 ### Minor Changes
 
 - Added support for X
   ([#123](https://example/123)).
 - Second note
+
+## [1.28.0] - 2026-06-08
+
+- Earlier point
 `;
 
     const result = postprocessChangelog({ changeLog, version: '1.29.0' });
@@ -97,8 +101,6 @@ describe('postprocessChangelog', () => {
     // notes out with blank lines, the flat format must still hold.
     const changeLog = `# Changelog
 
-## [Unreleased]
-
 ## 1.28.0
 ### Minor Changes
 
@@ -108,6 +110,10 @@ describe('postprocessChangelog', () => {
 
 
 - Second note
+
+## [1.27.3] - 2026-06-08
+
+- Earlier point
 `;
 
     const result = postprocessChangelog({ changeLog, version: '1.28.0' });
@@ -116,11 +122,9 @@ describe('postprocessChangelog', () => {
     expect(result).not.toMatch(/- First note\n\n- Second note/);
   });
 
-  it('moves the release block to directly after the Unreleased section', () => {
+  it('moves the release block before the previous release', () => {
     // `changeset version` appends the new block; it must end up above older ones.
     const changeLog = `# Changelog
-
-## [Unreleased]
 
 ## [1.27.2] - 2026-05-08
 
@@ -134,27 +138,27 @@ describe('postprocessChangelog', () => {
 
     const result = postprocessChangelog({ changeLog, version: '1.28.0' });
 
-    const unreleasedIndex = result.indexOf('## [Unreleased]');
     const newReleaseIndex = result.indexOf('## 1.28.0');
     const olderIndex = result.indexOf('## [1.27.2]');
-    expect(unreleasedIndex).toBeLessThan(newReleaseIndex);
     expect(newReleaseIndex).toBeLessThan(olderIndex);
   });
 
   it('ends with a single trailing newline', () => {
     const changeLog = `# Changelog
 
-## [Unreleased]
-
 ## 1.28.0
 ### Minor Changes
 
 - Note
+
+## [1.27.3] - 2026-06-08
+
+- Earlier point
 `;
 
     const result = postprocessChangelog({ changeLog, version: '1.28.0' });
 
-    expect(result.endsWith('- Note\n')).toBe(true);
+    expect(result.endsWith('\n')).toBe(true);
     expect(result.endsWith('\n\n')).toBe(false);
   });
 });

--- a/scripts/release-notes.js
+++ b/scripts/release-notes.js
@@ -12,7 +12,7 @@ async function main() {
   }
 
   if (!version) {
-    version = 'Unreleased';
+    throw new Error('Usage: node scripts/release-notes.js <version>');
   }
 
   const changeLogPath = url.fileURLToPath(

--- a/scripts/stamp-changelog-release-date.js
+++ b/scripts/stamp-changelog-release-date.js
@@ -6,10 +6,11 @@ import {
   getReleaseTargets,
 } from './release-notes/format-release-notes.js';
 
-// Stamps the Keep a Changelog release date onto the current version's changelog
-// heading at release time, e.g.
+// Finalizes the current version's changelog entry at release time by stamping
+// its release date and adding a comparison link, e.g.
 //
 //   ## 1.28.0  ->  ## [1.28.0] - 2026-06-08
+//   [1.28.0]: https://example.com/compare/v1.27.3...v1.28.0
 //
 // During `changeset version` the new release heading is left in its plain
 // `## <version>` form (see `postprocess-changeset-changelog.js` for why).
@@ -28,23 +29,74 @@ import {
 /**
  * Rewrites the plain `## <version>` heading into the dated Keep a Changelog
  * form, appending a `(… only)` annotation when the release targets a subset of
- * browsers.
+ * browsers, and adds a comparison link from the previous release.
  *
- * @param {{ changeLog: string; version: string; date: string }} options
+ * @param {{ changeLog: string; version: string; date: string; repositoryUrl: string }} options
  * @returns {string}
  */
-export function stampChangelogReleaseDate({ changeLog, version, date }) {
+export function stampChangelogReleaseDate({
+  changeLog,
+  version,
+  date,
+  repositoryUrl,
+}) {
   const headingRe = new RegExp(`^## ${escapeRegExp(version)}$`, 'm');
-  if (!headingRe.test(changeLog)) {
+  const headingMatch = headingRe.exec(changeLog);
+  if (!headingMatch) {
     // Already stamped (or the heading isn't present) — nothing to do.
     return changeLog;
+  }
+
+  const previousVersion = getPreviousVersion({
+    changeLog,
+    releaseHeadingEnd: headingMatch.index + headingMatch[0].length,
+  });
+  if (!previousVersion) {
+    throw new Error(`Could not find the release preceding ${version}`);
   }
 
   const annotation = formatTargetAnnotation(
     getReleaseTargets({ changeLog, version })
   );
 
-  return changeLog.replace(headingRe, `## [${version}] - ${date}${annotation}`);
+  const withHeading = changeLog.replace(
+    headingRe,
+    `## [${version}] - ${date}${annotation}`
+  );
+
+  return addVersionLink({
+    changeLog: withHeading,
+    version,
+    previousVersion,
+    repositoryUrl,
+  });
+}
+
+function getPreviousVersion({ changeLog, releaseHeadingEnd }) {
+  return changeLog
+    .slice(releaseHeadingEnd)
+    .match(/^##\s+\[?(\d+\.\d+\.\d+(?:[-+][^\]\s]+)?)\]?/m)?.[1];
+}
+
+function addVersionLink({
+  changeLog,
+  version,
+  previousVersion,
+  repositoryUrl,
+}) {
+  const versionLinkRe = new RegExp(`^\\[${escapeRegExp(version)}\\]:`, 'm');
+  if (versionLinkRe.test(changeLog)) {
+    return changeLog;
+  }
+
+  const normalizedRepositoryUrl = repositoryUrl.replace(/\/?(?:\.git)?$/, '');
+  const versionLink = `[${version}]: ${normalizedRepositoryUrl}/compare/v${previousVersion}...v${version}`;
+  const firstReferenceIndex = changeLog.search(/^\[[^\]]+\]:\s+\S+/m);
+  if (firstReferenceIndex === -1) {
+    return `${changeLog.trimEnd()}\n\n${versionLink}\n`;
+  }
+
+  return `${changeLog.slice(0, firstReferenceIndex)}${versionLink}\n${changeLog.slice(firstReferenceIndex)}`;
 }
 
 // Returns a human-readable ` (… only)` annotation when the release targets a
@@ -65,6 +117,10 @@ function main() {
   if (!version) {
     throw new Error('Could not find version in package.json');
   }
+  const repositoryUrl = packageJson.repository?.url;
+  if (!repositoryUrl) {
+    throw new Error('Could not find repository URL in package.json');
+  }
 
   const changeLogPath = url.fileURLToPath(
     new URL('../CHANGELOG.md', import.meta.url)
@@ -75,6 +131,7 @@ function main() {
     changeLog: original,
     version,
     date,
+    repositoryUrl,
   });
 
   if (updated === original) {

--- a/scripts/stamp-changelog-release-date.test.js
+++ b/scripts/stamp-changelog-release-date.test.js
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import { stampChangelogReleaseDate } from './stamp-changelog-release-date.js';
 
-const CHANGELOG = `# Changelog
+const REPOSITORY_URL = 'https://github.com/birchill/10ten-ja-reader.git';
 
-## [Unreleased]
+const CHANGELOG = `# Changelog
 
 ## 1.28.0
 
@@ -14,6 +14,8 @@ const CHANGELOG = `# Changelog
 ## [1.27.3] - 2026-06-08
 
 - Earlier point
+
+[1.27.3]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.2...v1.27.3
 `;
 
 describe('stampChangelogReleaseDate', () => {
@@ -22,10 +24,17 @@ describe('stampChangelogReleaseDate', () => {
       changeLog: CHANGELOG,
       version: '1.28.0',
       date: '2026-06-08',
+      repositoryUrl: REPOSITORY_URL,
     });
 
     expect(result).toContain('## [1.28.0] - 2026-06-08\n');
     expect(result).not.toContain('## 1.28.0\n');
+    expect(result).toContain(
+      '[1.28.0]: https://github.com/birchill/10ten-ja-reader/compare/v1.27.3...v1.28.0\n'
+    );
+    expect(result.indexOf('[1.28.0]:')).toBeLessThan(
+      result.indexOf('[1.27.3]:')
+    );
   });
 
   it('leaves already-dated headings of other versions untouched', () => {
@@ -33,6 +42,7 @@ describe('stampChangelogReleaseDate', () => {
       changeLog: CHANGELOG,
       version: '1.28.0',
       date: '2026-06-08',
+      repositoryUrl: REPOSITORY_URL,
     });
 
     expect(result).toContain('## [1.27.3] - 2026-06-08\n');
@@ -43,6 +53,7 @@ describe('stampChangelogReleaseDate', () => {
       changeLog: CHANGELOG,
       version: '1.28.0',
       date: '2026-06-08',
+      repositoryUrl: REPOSITORY_URL,
     });
 
     expect(result).toContain('## [1.28.0] - 2026-06-08\n');
@@ -64,6 +75,7 @@ describe('stampChangelogReleaseDate', () => {
       changeLog,
       version: '1.28.0',
       date: '2026-06-08',
+      repositoryUrl: REPOSITORY_URL,
     });
 
     expect(result).toContain(
@@ -83,6 +95,7 @@ describe('stampChangelogReleaseDate', () => {
       changeLog,
       version: '1.28.0',
       date: '2026-06-09',
+      repositoryUrl: REPOSITORY_URL,
     });
 
     expect(result).toBe(changeLog);


### PR DESCRIPTION
## Summary

The Changesets migration replaced the old Keep a Changelog plugin without replacing its release-link maintenance. As a result, the 1.28.0 heading had no link definition and the Unreleased comparison still started at 1.27.2.

- repair the 1.28.0 comparison link and remove the now-empty Unreleased section
- insert newly generated Changesets entries before the previous release without relying on an Unreleased heading
- add each released version comparison link when stamping its release date
- require an explicit version when manually generating release notes
- add regression coverage for the new ordering and link generation

## Testing

- `pnpm test` (29 files, 380 tests)