### PR TITLE
chore: upgrade to pnpm 12 and track latest in CI

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -82,7 +82,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/create-safari-test-build.yml
+++ b/.github/workflows/create-safari-test-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -71,7 +71,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -120,7 +120,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         if: ${{ steps.out.outputs.should_release == 'true' }}
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Install dependencies
         if: ${{ steps.out.outputs.should_release == 'true' }}
@@ -116,7 +116,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - name: Setup node
         uses: actions/setup-node@v7
@@ -306,7 +306,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11
+          version: latest
 
       - uses: actions/setup-node@v7
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-# Required when minimumReleaseAge is set in pnpm-workspace.yaml: with the
-# default `lowest-direct`, pnpm needs a `time` entry for every candidate
-# version and fails (ERR_PNPM_MISSING_TIME) when the registry's metadata
-# is incomplete (e.g. for @typescript-eslint/utils).
-# This setting is not honored from pnpm-workspace.yaml — it must live here.
-resolution-mode=highest

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ minimumReleaseAge: 1440 # 1 day
 minimumReleaseAgeExclude:
   - '@birchill/*'
   - react-cosmos-plugin-rspack
+
+# Avoid requiring release timestamps for every candidate in registry metadata.
+resolutionMode: highest


### PR DESCRIPTION
Use `version: latest` in the pnpm setup steps so CI picks up pnpm 12 and future stable releases. Move `resolutionMode: highest` from `.npmrc` to `pnpm-workspace.yaml`, where pnpm 12 reads project settings.

Validation with pnpm 12.3.4: `pnpm install --frozen-lockfile`, `pnpm build:firefox`, `pnpm test:unit`. Workflow YAML and `git diff --check` also pass.
