### PR TITLE
Keep reading audio playing after the popup closes

### DIFF
--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1368,6 +1368,7 @@ export class ContentHandler {
     if (this.isTopMostWindow()) {
       this.applyPuckConfig();
     } else {
+      this.#ttsPlaybackController?.stop();
       removePopup();
       this.clearResult();
       this.tearDownPuck();
@@ -1867,7 +1868,7 @@ export class ContentHandler {
     this.#currentPagePoint = undefined;
     this.#lastPointerTarget = null;
     this.#copyState = { kind: 'inactive' };
-    this.#ttsPlaybackController?.stop();
+    this.#ttsPlaybackController?.setEntries([]);
 
     clearPopupTimeout(this.#popupState);
     this.#popupState = undefined;

--- a/src/content/tts-playback-controller.test.ts
+++ b/src/content/tts-playback-controller.test.ts
@@ -196,7 +196,7 @@ describe('TtsPlaybackController', () => {
     });
   });
 
-  it('stops when the audio of the entry it is playing changes', async () => {
+  it('keeps the original audio playing when the displayed readings change', async () => {
     const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
     controller.toggle(1);
@@ -204,11 +204,11 @@ describe('TtsPlaybackController', () => {
 
     controller.setEntries([entryA, { id: entryB.id, requests: twoReadings }]);
 
-    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(playbacks[0].signal.aborted).toBe(false);
     expect(statuses()).toEqual(['idle', 'idle']);
   });
 
-  it('stops when the entry it is playing disappears', async () => {
+  it('keeps playing when the entry it is playing disappears', async () => {
     const { controller, statuses, playbacks } = setUp([entryA, entryB]);
 
     controller.toggle(1);
@@ -216,8 +216,102 @@ describe('TtsPlaybackController', () => {
 
     controller.setEntries([]);
 
-    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(playbacks[0].signal.aborted).toBe(false);
     expect(statuses()).toEqual(['idle', 'idle']);
+  });
+
+  it('restores playback state when the playing entry reappears', async () => {
+    const { controller, playbacks, statuses } = setUp([entryA, entryB]);
+
+    controller.toggle(1);
+    await flush();
+    const playing = controller.state;
+    controller.setEntries([]);
+    controller.setEntries([entryB, entryA]);
+
+    expect(playbacks[0].signal.aborted).toBe(false);
+    expect(controller.state).toEqual({ ...playing, activeEntryIndex: 0 });
+    expect(statuses()).toEqual(['playing', 'idle']);
+
+    controller.toggle(0);
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('finishes all readings after the popup entries are cleared', async () => {
+    const { controller, playbacks, unsubscribeAll } = setUp([
+      { id: 4, requests: twoReadings },
+    ]);
+
+    controller.toggle(0);
+    await flush();
+    controller.setEntries([]);
+    unsubscribeAll();
+    playbacks[0].end();
+    await flush();
+
+    expect(playbacks).toHaveLength(2);
+    expect(playbacks[1].signal.aborted).toBe(false);
+    expect(controller.state).toEqual({ kind: 'idle' });
+
+    playbacks[1].end();
+    await flush();
+    controller.setEntries([{ id: 4, requests: twoReadings }]);
+
+    expect(playbacks[1].signal.aborted).toBe(true);
+    expect(controller.state).toEqual({ kind: 'idle' });
+  });
+
+  it('continues loading after the popup entries are cleared', async () => {
+    const { controller, fetches, playbacks } = setUp([entryA], {
+      deferFetch: true,
+    });
+
+    controller.toggle(0);
+    controller.setEntries([]);
+
+    expect(fetches[0].signal.aborted).toBe(false);
+
+    fetches[0].resolve();
+    await flush();
+    controller.setEntries([entryA]);
+
+    expect(playbacks).toHaveLength(1);
+    expect(controller.state).toMatchObject({
+      kind: 'playing',
+      activeEntryIndex: 0,
+    });
+  });
+
+  it('replaces hidden playback when a different entry at the same index starts', async () => {
+    const { controller, playbacks, statuses } = setUp([entryA]);
+
+    controller.toggle(0);
+    await flush();
+    controller.setEntries([entryB]);
+
+    expect(statuses()).toEqual(['idle', 'idle']);
+
+    controller.toggle(0);
+    await flush();
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(playbacks).toHaveLength(2);
+    expect(statuses()).toEqual(['playing', 'idle']);
+  });
+
+  it('can explicitly stop playback after the popup entries are cleared', async () => {
+    const { controller, playbacks } = setUp([entryA]);
+
+    controller.toggle(0);
+    await flush();
+    controller.setEntries([]);
+    controller.stop();
+    controller.setEntries([entryA]);
+
+    expect(playbacks[0].signal.aborted).toBe(true);
+    expect(controller.state).toEqual({ kind: 'idle' });
   });
 
   it('fetches the clips again when an entry is played after it finished', async () => {

--- a/src/content/tts-playback-controller.ts
+++ b/src/content/tts-playback-controller.ts
@@ -35,7 +35,7 @@ export type TtsPlaybackHandle = Pick<
 export class TtsPlaybackController {
   #player: TtsPlayer;
   #entries: ReadonlyArray<TtsEntry> = [];
-  #activeEntry: { index: number; key: string } | undefined;
+  #activeEntry: { index: number | undefined; key: string } | undefined;
   #audioStarted = false;
   #actions: Array<() => void> = [];
   #draining = false;
@@ -115,7 +115,7 @@ export class TtsPlaybackController {
       }
 
       const state = this.#currentState();
-      if (state.kind === 'idle') {
+      if (this.#player.state.kind === 'idle') {
         this.#activeEntry = undefined;
       }
       if (!sameState(state, this.#state)) {
@@ -147,7 +147,7 @@ export class TtsPlaybackController {
   #currentState(): TtsPlaybackState {
     const playerState = this.#player.state;
     const active = this.#activeEntry;
-    if (playerState.kind === 'idle' || !active) {
+    if (playerState.kind === 'idle' || active?.index === undefined) {
       return { kind: 'idle' };
     }
 
@@ -183,18 +183,16 @@ export class TtsPlaybackController {
       return;
     }
 
-    const stillThere = entries[active.index];
+    const stillThere =
+      active.index === undefined ? undefined : entries[active.index];
     const index =
-      stillThere && entryKey(stillThere) === active.key
+      active.index !== undefined &&
+      stillThere &&
+      entryKey(stillThere) === active.key
         ? active.index
         : entries.findIndex((entry) => entryKey(entry) === active.key);
-    if (index < 0) {
-      this.#applyStop();
-      return;
-    }
-
     if (index !== active.index) {
-      this.#activeEntry = { ...active, index };
+      this.#activeEntry = { ...active, index: index < 0 ? undefined : index };
     }
   }
 


### PR DESCRIPTION
Why: Reading audio should keep playing when the popup closes, as agreed in [#3129](https://github.com/birchill/10ten-ja-reader/pull/3129#issuecomment-5566302025). Reopening the same word popup restores the highlight at the current reading. A different lookup doesn't show that highlight, even if it shares the same entry or reading; pressing play replaces the audio.

> Note: Renamed `#state` to `#publishedPopupState` and `#currentState()` to `#computePopupState()` to distinguish the published popup state, its calculation, and the audio player's state.

Stack:

- Follows #3108 at the top of the play-readings stack.
