### PR TITLE
chore: configure type-aware Oxlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm oxlint --type-aware scripts src tests "*.{cjs,js,ts}"
+        run: pnpm oxlint scripts src tests "*.{cjs,js,ts}"
 
       - name: Check formatting
         run: pnpm prettier --check _locales css scripts src tests "*.{js,json,md,ts}"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["eslint", "oxc", "react", "typescript", "unicorn", "vitest"],
   "categories": { "correctness": "error" },
+  "options": { "typeAware": true },
   "env": { "browser": true },
   "settings": { "react": { "version": "16.0", "pragma": "h" } },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "cosmos": "node --import=./cosmos-import.js node_modules/react-cosmos/bin/cosmos.js",
     "cosmos-export": "node --import=./cosmos-import.js node_modules/react-cosmos/bin/cosmos-export.js",
     "postinstall": "if-env RELEASE_BUILD=1 || husky",
-    "lint": "web-ext lint && oxlint --type-aware src/",
+    "lint": "web-ext lint && oxlint src/",
     "package": "rspack --env package",
     "package:chrome": "rspack --env target=chrome --env package",
     "package:chrome-electron": "rspack --env target=chrome-electron --env package",


### PR DESCRIPTION
Configure type-aware linting in the Oxlint config and remove redundant CLI flags from local and CI commands.\n\nTested with the repository Oxlint command.