### PR TITLE
chore: update Vitest WebdriverIO provider to stable v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@types/mocha": "10.0.10",
     "@types/webextension-polyfill": "0.12.6",
     "@types/yargs": "17.0.35",
-    "@vitest/browser-webdriverio": "5.0.0-rc.1",
+    "@vitest/browser-webdriverio": "5.0.0",
     "archiver": "8.0.0",
     "css-loader": "7.1.5",
     "fake-indexeddb": "6.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: 17.0.35
         version: 17.0.35
       '@vitest/browser-webdriverio':
-        specifier: 5.0.0-rc.1
-        version: 5.0.0-rc.1(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))
+        specifier: 5.0.0
+        version: 5.0.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))
       archiver:
         specifier: 8.0.0
         version: 8.0.0
@@ -179,7 +179,7 @@ importers:
         version: 4.23.13
       vitest:
         specifier: 5.0.0
-        version: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0-rc.1)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       web-ext-plugin:
         specifier: 2.13.0
         version: 2.13.0(express@5.2.1(supports-color@8.1.1))(jiti@2.7.0)(supports-color@8.1.1)
@@ -2082,11 +2082,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/browser-webdriverio@5.0.0-rc.1':
-    resolution: {integrity: sha512-drDDPcIu4pMJgp4EwaAmEgcxMVF6SvFvspL+1UAS7nIvfwPyBdb3ERU1C6eufDZtxN7Yeh9Dsq5Flad9hlAJxQ==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+  '@vitest/browser-webdriverio@5.0.0':
+    resolution: {integrity: sha512-faotr4XiQrpK7yK+GTSWTA2pYSPFMZZA+fXx0rtKh9mvAjCMBM0Q2UJ5NIv6o5Oqkn2CASIrKnePaC/37judJA==}
+    engines: {node: ^22.12.0 || ^24.0.0 || >=26.0.0}
     peerDependencies:
-      vitest: ^5.0.0-beta.5
+      vitest: ^5.0.0
       webdriverio: '*'
 
   '@vitest/browser@5.0.0':
@@ -6911,10 +6911,10 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitest/browser-webdriverio@5.0.0-rc.1(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))':
+  '@vitest/browser-webdriverio@5.0.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))':
     dependencies:
       '@vitest/browser': 5.0.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)
-      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0-rc.1)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       webdriverio: 9.22.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
@@ -6932,7 +6932,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0-rc.1)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -6963,7 +6963,7 @@ snapshots:
       pathe: 2.0.3
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0-rc.1)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      vitest: 5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
 
   '@vitest/utils@5.0.0':
     dependencies:
@@ -10101,7 +10101,7 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.9.0
 
-  vitest@5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0-rc.1)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
+  vitest@5.0.0(@types/node@24.3.0)(@vitest/browser-webdriverio@5.0.0)(@vitest/ui@5.0.0)(jsdom@30.0.1)(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/mocker': 5.0.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
@@ -10119,7 +10119,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.0
-      '@vitest/browser-webdriverio': 5.0.0-rc.1(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))
+      '@vitest/browser-webdriverio': 5.0.0(vite@7.1.3(@types/node@24.3.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))(vitest@5.0.0)(webdriverio@9.22.0(supports-color@8.1.1))
       '@vitest/ui': 5.0.0(vitest@5.0.0)
       jsdom: 30.0.1
     transitivePeerDependencies:


### PR DESCRIPTION
Update `@vitest/browser-webdriverio` from `5.0.0-rc.1` to `5.0.0`, matching the existing Vitest 5 runner. The stable provider is maintained in the vitest-community repository under the same package name.

Validation on Node 24:
- `pnpm test --project unit`: 155 passed
- `pnpm test --project browser --browser chrome`: 113 passed

Migration guide: https://vitest.dev/guide/migration/
